### PR TITLE
【feature/21】削除機能の追加

### DIFF
--- a/app/recipes/[id]/DeleteButton.test.tsx
+++ b/app/recipes/[id]/DeleteButton.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const { mockDeleteRecipe } = vi.hoisted(() => ({
+  mockDeleteRecipe: vi.fn(),
+}))
+
+vi.mock('../actions', () => ({
+  deleteRecipe: mockDeleteRecipe,
+}))
+
+import DeleteButton from './DeleteButton'
+
+describe('DeleteButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(false))
+  })
+
+  it('「レシピを削除」ボタンが表示される', () => {
+    render(<DeleteButton recipeId="recipe-1" />)
+    expect(screen.getByRole('button', { name: 'レシピを削除' })).toBeInTheDocument()
+  })
+
+  it('クリックすると confirm ダイアログが表示される', async () => {
+    const user = userEvent.setup()
+    render(<DeleteButton recipeId="recipe-1" />)
+
+    await user.click(screen.getByRole('button', { name: 'レシピを削除' }))
+
+    expect(window.confirm).toHaveBeenCalledWith('このレシピを削除してもよろしいですか？')
+  })
+
+  it('confirm キャンセル時: deleteRecipe が呼ばれない', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(false))
+    const user = userEvent.setup()
+    render(<DeleteButton recipeId="recipe-1" />)
+
+    await user.click(screen.getByRole('button', { name: 'レシピを削除' }))
+
+    expect(mockDeleteRecipe).not.toHaveBeenCalled()
+  })
+
+  it('confirm OK 時: deleteRecipe(recipeId) が呼ばれる', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true))
+    mockDeleteRecipe.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    render(<DeleteButton recipeId="recipe-1" />)
+
+    await user.click(screen.getByRole('button', { name: 'レシピを削除' }))
+
+    expect(mockDeleteRecipe).toHaveBeenCalledWith('recipe-1')
+  })
+})

--- a/app/recipes/[id]/DeleteButton.tsx
+++ b/app/recipes/[id]/DeleteButton.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { useTransition } from 'react'
+import { deleteRecipe } from '../actions'
+
+export default function DeleteButton({ recipeId }: { recipeId: string }) {
+  const [isPending, startTransition] = useTransition()
+
+  const handleDelete = () => {
+    if (!window.confirm('このレシピを削除してもよろしいですか？')) return
+    startTransition(async () => {
+      await deleteRecipe(recipeId)
+    })
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleDelete}
+      disabled={isPending}
+      className="px-4 py-2 rounded-lg text-sm font-medium text-red-600 border border-red-200 hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {isPending ? '削除中...' : 'レシピを削除'}
+    </button>
+  )
+}

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '../../utils/supabase/server'
 import { prisma } from '../../../lib/prisma'
+import DeleteButton from './DeleteButton'
 
 type Props = {
   params: Promise<{ id: string }>
@@ -30,7 +31,8 @@ export default async function RecipeDetailPage({ params }: Props) {
           <Link href="/" className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
             ← 一覧へ
           </Link>
-          <h1 className="text-lg font-semibold text-zinc-900 truncate">{recipe.title}</h1>
+          <h1 className="text-lg font-semibold text-zinc-900 truncate flex-1">{recipe.title}</h1>
+          <DeleteButton recipeId={recipe.id} />
         </div>
       </header>
 

--- a/app/recipes/actions.test.ts
+++ b/app/recipes/actions.test.ts
@@ -4,11 +4,15 @@ const {
   mockGetUser,
   mockRecipeCreate,
   mockCategoryUpsert,
+  mockRecipeDelete,
+  mockRecipeFindFirst,
   mockRedirect,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockRecipeCreate: vi.fn(),
   mockCategoryUpsert: vi.fn(),
+  mockRecipeDelete: vi.fn(),
+  mockRecipeFindFirst: vi.fn(),
   mockRedirect: vi.fn(),
 }))
 
@@ -20,7 +24,7 @@ vi.mock('../utils/supabase/server', () => ({
 
 vi.mock('../../lib/prisma', () => ({
   prisma: {
-    recipe: { create: mockRecipeCreate },
+    recipe: { create: mockRecipeCreate, delete: mockRecipeDelete, findFirst: mockRecipeFindFirst },
     category: { upsert: mockCategoryUpsert },
   },
 }))
@@ -29,7 +33,7 @@ vi.mock('next/navigation', () => ({
   redirect: mockRedirect,
 }))
 
-import { createRecipe } from './actions'
+import { createRecipe, deleteRecipe } from './actions'
 
 const baseInput = {
   title: '肉じゃが',
@@ -53,7 +57,7 @@ describe('createRecipe', () => {
     expect(mockRedirect).toHaveBeenCalledWith('/login')
   })
 
-  it('成功時: prisma.recipe.create を呼び、/recipes/:id にリダイレクトする', async () => {
+  it('成功時: prisma.recipe.create を呼び、/ にリダイレクトする', async () => {
     mockGetUser.mockResolvedValue({
       data: { user: { id: 'user-1' } },
     })
@@ -70,7 +74,7 @@ describe('createRecipe', () => {
         }),
       })
     )
-    expect(mockRedirect).toHaveBeenCalledWith('/recipes/recipe-abc')
+    expect(mockRedirect).toHaveBeenCalledWith('/')
   })
 
   it('servings・cookTime が数値文字列の場合: parseInt して渡す', async () => {
@@ -207,5 +211,42 @@ describe('createRecipe', () => {
     expect(mockCategoryUpsert).toHaveBeenCalledWith(
       expect.objectContaining({ where: { name: '和食' } })
     )
+  })
+})
+
+describe('deleteRecipe', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('未認証の場合: prisma.recipe.delete を呼ばず /login にリダイレクトする', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    await deleteRecipe('recipe-1')
+
+    expect(mockRecipeDelete).not.toHaveBeenCalled()
+    expect(mockRedirect).toHaveBeenCalledWith('/login')
+  })
+
+  it('他人のレシピの場合: prisma.recipe.delete を呼ばず / にリダイレクトする', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue(null)
+
+    await deleteRecipe('recipe-other')
+
+    expect(mockRecipeDelete).not.toHaveBeenCalled()
+    expect(mockRedirect).toHaveBeenCalledWith('/')
+  })
+
+  it('自分のレシピの場合: prisma.recipe.delete を呼び / にリダイレクトする', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockRecipeDelete.mockResolvedValue({})
+
+    await deleteRecipe('recipe-1')
+
+    expect(mockRecipeFindFirst).toHaveBeenCalledWith({
+      where: { id: 'recipe-1', userId: 'user-1' },
+    })
+    expect(mockRecipeDelete).toHaveBeenCalledWith({ where: { id: 'recipe-1' } })
+    expect(mockRedirect).toHaveBeenCalledWith('/')
   })
 })

--- a/app/recipes/actions.ts
+++ b/app/recipes/actions.ts
@@ -1,3 +1,4 @@
+
 'use server'
 
 import { redirect } from 'next/navigation'
@@ -82,5 +83,29 @@ export async function createRecipe(input: CreateRecipeInput) {
     },
   })
 
+  redirect('/')
+}
+
+export async function deleteRecipe(recipeId: string) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+    return
+  }
+
+  const recipe = await prisma.recipe.findFirst({
+    where: { id: recipeId, userId: user.id },
+  })
+
+  if (!recipe) {
+    redirect('/')
+    return
+  }
+
+  await prisma.recipe.delete({ where: { id: recipeId } })
   redirect('/')
 }


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
登録したレシピを削除する

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #21 

## やったこと
<!-- このPRで何をしたのか -->
- deleteRecipe Server Action を追加（app/recipes/actions.ts）
- 削除ボタン Client Component を新規作成（app/recipes/[id]/DeleteButton.tsx）
- レシピ詳細ページのヘッダーに削除ボタンを組み込み（app/recipes/[id]/page.tsx）

deleteRecipe は以下の順で検証する
1. 未認証 → /login にリダイレクト
2. 他人のレシピ（findFirst で userId 一致確認）→ / にリダイレクト
3. 自分のレシピ → 削除して / にリダイレクト
関連データ（Ingredient, Step, RecipeCategory）は Prisma スキーマの onDelete: Cascade により自動削除される。

UT
- deleteRecipe のユニットテスト（未認証・他人のレシピ・自分のレシピ の3ケース）
- DeleteButton のコンポーネントテスト（ボタン表示・confirm呼び出し・キャンセル・OK の4ケース）
- /recipes/:id に「レシピを削除」ボタンが表示される
- ボタンクリック → confirm ダイアログが表示される
- キャンセル → ページが変わらず削除されない
- OK → / に遷移し、削除したレシピが一覧から消えている

## やらないこと
<!-- このPRでやらないことは何か -->
- なし

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
