### PR TITLE
【feature/20】レシピ編集機能の実装

### DIFF
--- a/app/recipes/[id]/edit/EditRecipeForm.tsx
+++ b/app/recipes/[id]/edit/EditRecipeForm.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { isRedirectError } from 'next/dist/client/components/redirect-error'
+import { updateRecipe, type IngredientInput, type StepInput } from '../../actions'
+
+type InitialValues = {
+  title: string
+  description: string
+  servings: string
+  cookTime: string
+  ingredients: IngredientInput[]
+  steps: StepInput[]
+  categories: string[]
+}
+
+type Props = {
+  recipeId: string
+  initialValues: InitialValues
+}
+
+export default function EditRecipeForm({ recipeId, initialValues }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  const [title, setTitle] = useState(initialValues.title)
+  const [description, setDescription] = useState(initialValues.description)
+  const [servings, setServings] = useState(initialValues.servings)
+  const [cookTime, setCookTime] = useState(initialValues.cookTime)
+  const [ingredients, setIngredients] = useState<IngredientInput[]>(initialValues.ingredients)
+  const [steps, setSteps] = useState<StepInput[]>(initialValues.steps)
+  const [categoryInput, setCategoryInput] = useState('')
+  const [categories, setCategories] = useState<string[]>(initialValues.categories)
+
+  const addIngredient = () =>
+    setIngredients((prev) => [...prev, { name: '', amount: '', unit: '' }])
+  const removeIngredient = (index: number) =>
+    setIngredients((prev) => prev.filter((_, i) => i !== index))
+  const updateIngredient = (index: number, field: keyof IngredientInput, value: string) =>
+    setIngredients((prev) =>
+      prev.map((ing, i) => (i === index ? { ...ing, [field]: value } : ing))
+    )
+
+  const addStep = () => setSteps((prev) => [...prev, { description: '' }])
+  const removeStep = (index: number) =>
+    setSteps((prev) => prev.filter((_, i) => i !== index))
+  const updateStep = (index: number, value: string) =>
+    setSteps((prev) =>
+      prev.map((step, i) => (i === index ? { description: value } : step))
+    )
+
+  const addCategory = () => {
+    const trimmed = categoryInput.trim()
+    if (!trimmed || categories.includes(trimmed)) return
+    setCategories((prev) => [...prev, trimmed])
+    setCategoryInput('')
+  }
+  const removeCategory = (name: string) =>
+    setCategories((prev) => prev.filter((c) => c !== name))
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) {
+      setError('タイトルを入力してください。')
+      return
+    }
+    setError(null)
+    startTransition(async () => {
+      try {
+        await updateRecipe(recipeId, { title, description, servings, cookTime, ingredients, steps, categories })
+      } catch (err) {
+        if (isRedirectError(err)) throw err
+        setError('保存に失敗しました。もう一度お試しください。')
+      }
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50">
+      <header className="bg-white border-b border-zinc-200">
+        <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors"
+          >
+            ← 戻る
+          </button>
+          <h1 className="text-lg font-semibold text-zinc-900">レシピを編集</h1>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-8">
+        <form onSubmit={handleSubmit} className="space-y-8">
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+              {error}
+            </p>
+          )}
+
+          {/* 基本情報 */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">基本情報</h2>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 mb-1">
+                タイトル <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-600">必須</span>
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="例: 肉じゃが"
+                className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 mb-1">説明・メモ <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="レシピの概要や備考など"
+                rows={3}
+                className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 resize-none"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">人数 <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    min="1"
+                    value={servings}
+                    onChange={(e) => setServings(e.target.value)}
+                    placeholder="2"
+                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 pr-8"
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-zinc-400">人</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">調理時間 <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    min="1"
+                    value={cookTime}
+                    onChange={(e) => setCookTime(e.target.value)}
+                    placeholder="30"
+                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 pr-10"
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-zinc-400">分</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* カテゴリ */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">カテゴリ <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></h2>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={categoryInput}
+                onChange={(e) => setCategoryInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCategory() } }}
+                placeholder="例: 和食、夕食、お弁当"
+                className="flex-1 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+              />
+              <button
+                type="button"
+                onClick={addCategory}
+                className="px-4 py-2 text-sm font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 transition-colors"
+              >
+                追加
+              </button>
+            </div>
+            {categories.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {categories.map((cat) => (
+                  <span key={cat} className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm bg-zinc-100 text-zinc-700">
+                    {cat}
+                    <button type="button" onClick={() => removeCategory(cat)} className="text-zinc-400 hover:text-zinc-700 transition-colors leading-none">×</button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* 材料 */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">材料 <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></h2>
+            <div className="space-y-2">
+              {ingredients.map((ing, index) => (
+                <div key={index} className="flex gap-2 items-center">
+                  <input
+                    type="text"
+                    value={ing.name}
+                    onChange={(e) => updateIngredient(index, 'name', e.target.value)}
+                    placeholder="材料名"
+                    className="flex-1 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+                  />
+                  <input
+                    type="text"
+                    value={ing.amount}
+                    onChange={(e) => updateIngredient(index, 'amount', e.target.value)}
+                    placeholder="量"
+                    className="w-20 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+                  />
+                  <input
+                    type="text"
+                    value={ing.unit}
+                    onChange={(e) => updateIngredient(index, 'unit', e.target.value)}
+                    placeholder="単位"
+                    className="w-20 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+                  />
+                  {ingredients.length > 1 && (
+                    <button type="button" onClick={() => removeIngredient(index)} className="text-zinc-400 hover:text-red-500 transition-colors text-lg leading-none">×</button>
+                  )}
+                </div>
+              ))}
+            </div>
+            <button type="button" onClick={addIngredient} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+              + 材料を追加
+            </button>
+          </section>
+
+          {/* 手順 */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">手順 <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></h2>
+            <div className="space-y-3">
+              {steps.map((step, index) => (
+                <div key={index} className="flex gap-3 items-start">
+                  <span className="mt-2.5 flex-shrink-0 w-6 h-6 rounded-full bg-zinc-900 text-white text-xs flex items-center justify-center font-medium">
+                    {index + 1}
+                  </span>
+                  <textarea
+                    value={step.description}
+                    onChange={(e) => updateStep(index, e.target.value)}
+                    placeholder={`手順 ${index + 1}`}
+                    rows={2}
+                    className="flex-1 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 resize-none"
+                  />
+                  {steps.length > 1 && (
+                    <button type="button" onClick={() => removeStep(index)} className="mt-2.5 text-zinc-400 hover:text-red-500 transition-colors text-lg leading-none">×</button>
+                  )}
+                </div>
+              ))}
+            </div>
+            <button type="button" onClick={addStep} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+              + 手順を追加
+            </button>
+          </section>
+
+          {/* 送信 */}
+          <div className="flex gap-3 pb-8">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="flex-1 py-3 rounded-xl border border-zinc-300 text-sm font-medium text-zinc-700 hover:bg-zinc-50 transition-colors"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isPending}
+              className="flex-1 py-3 rounded-xl bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isPending ? '保存中...' : '変更を保存'}
+            </button>
+          </div>
+        </form>
+      </main>
+    </div>
+  )
+}

--- a/app/recipes/[id]/edit/page.test.tsx
+++ b/app/recipes/[id]/edit/page.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const { mockUpdateRecipe, mockRouterBack } = vi.hoisted(() => ({
+  mockUpdateRecipe: vi.fn(),
+  mockRouterBack: vi.fn(),
+}))
+
+vi.mock('../../actions', () => ({
+  updateRecipe: mockUpdateRecipe,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: mockRouterBack }),
+}))
+
+import EditRecipeForm from './EditRecipeForm'
+
+const defaultInitialValues = {
+  title: '肉じゃが',
+  description: 'おふくろの味',
+  servings: '4',
+  cookTime: '30',
+  ingredients: [{ name: 'じゃがいも', amount: '2', unit: '個' }],
+  steps: [{ description: '具材を炒める' }],
+  categories: ['和食'],
+}
+
+describe('EditRecipeForm', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('各セクション（基本情報・カテゴリ・材料・手順）が表示される', () => {
+    render(<EditRecipeForm recipeId="recipe-1" initialValues={defaultInitialValues} />)
+
+    expect(screen.getByText('基本情報')).toBeInTheDocument()
+    expect(screen.getByText('カテゴリ')).toBeInTheDocument()
+    expect(screen.getByText('材料')).toBeInTheDocument()
+    expect(screen.getByText('手順')).toBeInTheDocument()
+  })
+
+  it('initialValues がフォームに反映される', () => {
+    render(<EditRecipeForm recipeId="recipe-1" initialValues={defaultInitialValues} />)
+
+    expect(screen.getByDisplayValue('肉じゃが')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('おふくろの味')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('4')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('30')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('じゃがいも')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('具材を炒める')).toBeInTheDocument()
+    expect(screen.getByText('和食')).toBeInTheDocument()
+  })
+
+  it('タイトル空で送信するとエラーメッセージが表示され updateRecipe が呼ばれない', async () => {
+    const user = userEvent.setup()
+    render(
+      <EditRecipeForm
+        recipeId="recipe-1"
+        initialValues={{ ...defaultInitialValues, title: '' }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: '変更を保存' }))
+
+    expect(screen.getByText('タイトルを入力してください。')).toBeInTheDocument()
+    expect(mockUpdateRecipe).not.toHaveBeenCalled()
+  })
+
+  it('送信で updateRecipe(recipeId, input) が呼ばれる', async () => {
+    const user = userEvent.setup()
+    mockUpdateRecipe.mockResolvedValue(undefined)
+    render(<EditRecipeForm recipeId="recipe-1" initialValues={defaultInitialValues} />)
+
+    await user.click(screen.getByRole('button', { name: '変更を保存' }))
+
+    await waitFor(() => {
+      expect(mockUpdateRecipe).toHaveBeenCalledWith(
+        'recipe-1',
+        expect.objectContaining({ title: '肉じゃが' })
+      )
+    })
+  })
+
+  it('「+ 材料を追加」を押すと材料の入力行が増える', async () => {
+    const user = userEvent.setup()
+    render(<EditRecipeForm recipeId="recipe-1" initialValues={defaultInitialValues} />)
+
+    const before = screen.getAllByPlaceholderText('材料名').length
+    await user.click(screen.getByRole('button', { name: '+ 材料を追加' }))
+    const after = screen.getAllByPlaceholderText('材料名').length
+
+    expect(after).toBe(before + 1)
+  })
+
+  it('× を押すと材料行が削除される', async () => {
+    const user = userEvent.setup()
+    render(
+      <EditRecipeForm
+        recipeId="recipe-1"
+        initialValues={{
+          ...defaultInitialValues,
+          categories: [],
+          ingredients: [
+            { name: 'じゃがいも', amount: '2', unit: '個' },
+            { name: '玉ねぎ', amount: '1', unit: '個' },
+          ],
+        }}
+      />
+    )
+
+    expect(screen.getAllByPlaceholderText('材料名')).toHaveLength(2)
+    const deleteButtons = screen.getAllByRole('button', { name: '×' })
+    await user.click(deleteButtons[0])
+    expect(screen.getAllByPlaceholderText('材料名')).toHaveLength(1)
+  })
+
+  it('「+ 手順を追加」を押すと手順の入力欄が増える', async () => {
+    const user = userEvent.setup()
+    render(<EditRecipeForm recipeId="recipe-1" initialValues={defaultInitialValues} />)
+
+    const before = screen.getAllByPlaceholderText(/手順 \d/).length
+    await user.click(screen.getByRole('button', { name: '+ 手順を追加' }))
+    const after = screen.getAllByPlaceholderText(/手順 \d/).length
+
+    expect(after).toBe(before + 1)
+  })
+
+  it('カテゴリを追加・削除できる', async () => {
+    const user = userEvent.setup()
+    render(<EditRecipeForm recipeId="recipe-1" initialValues={defaultInitialValues} />)
+
+    await user.type(screen.getByPlaceholderText('例: 和食、夕食、お弁当'), '夕食')
+    await user.click(screen.getByRole('button', { name: '追加' }))
+    expect(screen.getByText('夕食')).toBeInTheDocument()
+
+    // 和食タグの × を押して削除
+    const deleteButtons = screen.getAllByRole('button', { name: '×' })
+    // カテゴリの × ボタンを特定（材料・手順の × とは別）
+    await user.click(deleteButtons[deleteButtons.length - 1])
+    expect(screen.queryByText('夕食')).not.toBeInTheDocument()
+  })
+})

--- a/app/recipes/[id]/edit/page.tsx
+++ b/app/recipes/[id]/edit/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from 'next/navigation'
+import { createClient } from '../../../utils/supabase/server'
+import { prisma } from '../../../../lib/prisma'
+import EditRecipeForm from './EditRecipeForm'
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export default async function EditRecipePage({ params }: Props) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const recipe = await prisma.recipe.findFirst({
+    where: { id, userId: user!.id },
+    include: {
+      ingredients: { orderBy: { order: 'asc' } },
+      steps: { orderBy: { order: 'asc' } },
+      categories: { include: { category: true } },
+    },
+  })
+
+  if (!recipe) notFound()
+
+  const initialValues = {
+    title: recipe.title,
+    description: recipe.description ?? '',
+    servings: recipe.servings ? String(recipe.servings) : '',
+    cookTime: recipe.cookTime ? String(recipe.cookTime) : '',
+    ingredients: recipe.ingredients.map((ing) => ({
+      name: ing.name,
+      amount: ing.amount ?? '',
+      unit: ing.unit ?? '',
+    })),
+    steps: recipe.steps.map((step) => ({ description: step.description })),
+    categories: recipe.categories.map((rc) => rc.category.name),
+  }
+
+  return <EditRecipeForm recipeId={recipe.id} initialValues={initialValues} />
+}

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -32,6 +32,12 @@ export default async function RecipeDetailPage({ params }: Props) {
             ← 一覧へ
           </Link>
           <h1 className="text-lg font-semibold text-zinc-900 truncate flex-1">{recipe.title}</h1>
+          <Link
+            href={`/recipes/${recipe.id}/edit`}
+            className="px-4 py-2 rounded-lg text-sm font-medium text-zinc-700 border border-zinc-200 hover:bg-zinc-50 transition-colors"
+          >
+            編集
+          </Link>
           <DeleteButton recipeId={recipe.id} />
         </div>
       </header>

--- a/app/recipes/actions.test.ts
+++ b/app/recipes/actions.test.ts
@@ -3,16 +3,32 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const {
   mockGetUser,
   mockRecipeCreate,
+  mockRecipeUpdate,
   mockCategoryUpsert,
   mockRecipeDelete,
   mockRecipeFindFirst,
+  mockIngredientDeleteMany,
+  mockStepDeleteMany,
+  mockRecipeCategoryDeleteMany,
+  mockIngredientCreateMany,
+  mockStepCreateMany,
+  mockRecipeCategoryCreateMany,
+  mockTransaction,
   mockRedirect,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockRecipeCreate: vi.fn(),
+  mockRecipeUpdate: vi.fn(),
   mockCategoryUpsert: vi.fn(),
   mockRecipeDelete: vi.fn(),
   mockRecipeFindFirst: vi.fn(),
+  mockIngredientDeleteMany: vi.fn(),
+  mockStepDeleteMany: vi.fn(),
+  mockRecipeCategoryDeleteMany: vi.fn(),
+  mockIngredientCreateMany: vi.fn(),
+  mockStepCreateMany: vi.fn(),
+  mockRecipeCategoryCreateMany: vi.fn(),
+  mockTransaction: vi.fn(),
   mockRedirect: vi.fn(),
 }))
 
@@ -24,8 +40,12 @@ vi.mock('../utils/supabase/server', () => ({
 
 vi.mock('../../lib/prisma', () => ({
   prisma: {
-    recipe: { create: mockRecipeCreate, delete: mockRecipeDelete, findFirst: mockRecipeFindFirst },
+    recipe: { create: mockRecipeCreate, update: mockRecipeUpdate, delete: mockRecipeDelete, findFirst: mockRecipeFindFirst },
     category: { upsert: mockCategoryUpsert },
+    ingredient: { deleteMany: mockIngredientDeleteMany, createMany: mockIngredientCreateMany },
+    step: { deleteMany: mockStepDeleteMany, createMany: mockStepCreateMany },
+    recipeCategory: { deleteMany: mockRecipeCategoryDeleteMany, createMany: mockRecipeCategoryCreateMany },
+    $transaction: mockTransaction,
   },
 }))
 
@@ -33,7 +53,7 @@ vi.mock('next/navigation', () => ({
   redirect: mockRedirect,
 }))
 
-import { createRecipe, deleteRecipe } from './actions'
+import { createRecipe, deleteRecipe, updateRecipe } from './actions'
 
 const baseInput = {
   title: '肉じゃが',
@@ -210,6 +230,134 @@ describe('createRecipe', () => {
     expect(mockCategoryUpsert).toHaveBeenCalledTimes(1)
     expect(mockCategoryUpsert).toHaveBeenCalledWith(
       expect.objectContaining({ where: { name: '和食' } })
+    )
+  })
+})
+
+describe('updateRecipe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTransaction.mockImplementation(async (queries: Promise<unknown>[]) => Promise.all(queries))
+    mockIngredientDeleteMany.mockResolvedValue({})
+    mockStepDeleteMany.mockResolvedValue({})
+    mockRecipeCategoryDeleteMany.mockResolvedValue({})
+    mockRecipeUpdate.mockResolvedValue({ id: 'recipe-1' })
+    mockIngredientCreateMany.mockResolvedValue({})
+    mockStepCreateMany.mockResolvedValue({})
+    mockRecipeCategoryCreateMany.mockResolvedValue({})
+  })
+
+  it('未認証の場合: /login にリダイレクトし $transaction を呼ばない', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    await updateRecipe('recipe-1', baseInput)
+
+    expect(mockTransaction).not.toHaveBeenCalled()
+    expect(mockRedirect).toHaveBeenCalledWith('/login')
+  })
+
+  it('他人のレシピの場合: / にリダイレクトし $transaction を呼ばない', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue(null)
+
+    await updateRecipe('recipe-other', baseInput)
+
+    expect(mockTransaction).not.toHaveBeenCalled()
+    expect(mockRedirect).toHaveBeenCalledWith('/')
+  })
+
+  it('成功時: $transaction を呼び /recipes/recipe-1 にリダイレクトする', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+
+    await updateRecipe('recipe-1', baseInput)
+
+    expect(mockTransaction).toHaveBeenCalled()
+    expect(mockRedirect).toHaveBeenCalledWith('/recipes/recipe-1')
+  })
+
+  it('servings・cookTime が数値文字列の場合: parseInt して update に渡す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+
+    await updateRecipe('recipe-1', { ...baseInput, servings: '4', cookTime: '30' })
+
+    expect(mockRecipeUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ servings: 4, cookTime: 30 }),
+      })
+    )
+  })
+
+  it('servings・cookTime が空文字の場合: null を update に渡す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+
+    await updateRecipe('recipe-1', { ...baseInput, servings: '', cookTime: '' })
+
+    expect(mockRecipeUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ servings: null, cookTime: null }),
+      })
+    )
+  })
+
+  it('name が空の材料はフィルタリングされる', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+
+    await updateRecipe('recipe-1', {
+      ...baseInput,
+      ingredients: [
+        { name: 'じゃがいも', amount: '2', unit: '個' },
+        { name: '  ', amount: '', unit: '' },
+      ],
+    })
+
+    expect(mockIngredientCreateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([expect.objectContaining({ name: 'じゃがいも' })]),
+      })
+    )
+    const createCall = mockIngredientCreateMany.mock.calls[0][0]
+    expect(createCall.data).toHaveLength(1)
+  })
+
+  it('description が空の手順はフィルタリングされる', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+
+    await updateRecipe('recipe-1', {
+      ...baseInput,
+      steps: [{ description: '具材を炒める' }, { description: '' }],
+    })
+
+    expect(mockStepCreateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([expect.objectContaining({ description: '具材を炒める' })]),
+      })
+    )
+    const createCall = mockStepCreateMany.mock.calls[0][0]
+    expect(createCall.data).toHaveLength(1)
+  })
+
+  it('カテゴリがある場合: prisma.category.upsert を呼ぶ', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockCategoryUpsert
+      .mockResolvedValueOnce({ id: 'cat-1' })
+      .mockResolvedValueOnce({ id: 'cat-2' })
+
+    await updateRecipe('recipe-1', { ...baseInput, categories: ['和食', '夕食'] })
+
+    expect(mockCategoryUpsert).toHaveBeenCalledTimes(2)
+    expect(mockRecipeCategoryCreateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [
+          { recipeId: 'recipe-1', categoryId: 'cat-1' },
+          { recipeId: 'recipe-1', categoryId: 'cat-2' },
+        ],
+      })
     )
   })
 })

--- a/app/recipes/actions.ts
+++ b/app/recipes/actions.ts
@@ -86,6 +86,84 @@ export async function createRecipe(input: CreateRecipeInput) {
   redirect('/')
 }
 
+export type UpdateRecipeInput = CreateRecipeInput
+
+export async function updateRecipe(recipeId: string, input: UpdateRecipeInput) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+    return
+  }
+
+  const recipe = await prisma.recipe.findFirst({
+    where: { id: recipeId, userId: user.id },
+  })
+
+  if (!recipe) {
+    redirect('/')
+    return
+  }
+
+  const servings = input.servings ? parseInt(input.servings, 10) : null
+  const cookTime = input.cookTime ? parseInt(input.cookTime, 10) : null
+
+  const categoryIds: string[] = []
+  for (const name of input.categories) {
+    const trimmed = name.trim()
+    if (!trimmed) continue
+    const category = await prisma.category.upsert({
+      where: { name: trimmed },
+      update: {},
+      create: { name: trimmed },
+    })
+    categoryIds.push(category.id)
+  }
+
+  const filteredIngredients = input.ingredients
+    .filter((ing) => ing.name.trim())
+    .map((ing, index) => ({
+      recipeId,
+      name: ing.name.trim(),
+      amount: ing.amount.trim() || null,
+      unit: ing.unit.trim() || null,
+      order: index,
+    }))
+
+  const filteredSteps = input.steps
+    .filter((step) => step.description.trim())
+    .map((step, index) => ({
+      recipeId,
+      description: step.description.trim(),
+      order: index,
+    }))
+
+  await prisma.$transaction([
+    prisma.ingredient.deleteMany({ where: { recipeId } }),
+    prisma.step.deleteMany({ where: { recipeId } }),
+    prisma.recipeCategory.deleteMany({ where: { recipeId } }),
+    prisma.recipe.update({
+      where: { id: recipeId },
+      data: {
+        title: input.title,
+        description: input.description || null,
+        servings,
+        cookTime,
+      },
+    }),
+    prisma.ingredient.createMany({ data: filteredIngredients }),
+    prisma.step.createMany({ data: filteredSteps }),
+    prisma.recipeCategory.createMany({
+      data: categoryIds.map((categoryId) => ({ recipeId, categoryId })),
+    }),
+  ])
+
+  redirect(`/recipes/${recipeId}`)
+}
+
 export async function deleteRecipe(recipeId: string) {
   const supabase = await createClient()
   const {


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
登録したレシピを編集する機能を実装

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #20 

## やったこと
<!-- このPRで何をしたのか -->
- updateRecipe(recipeId, input) Server Action を追加
- 材料・手順・カテゴリを $transaction 内で全置き換え（deleteMany → createMany）

app/recipes/[id]/edit/page.tsx （新規）
- サーバーコンポーネント
- DBからレシピを取得し、initialValues を組み立てて EditRecipeForm に渡す

app/recipes/[id]/edit/EditRecipeForm.tsx （新規）
- クライアントコンポーネント
- new/page.tsx と同じUI構成で、初期値を props から受け取る
- 送信時に updateRecipe(recipeId, ...) を呼び出す

app/recipes/[id]/page.tsx
- ヘッダーに「編集」ボタンを追加

テスト
- app/recipes/actions.test.ts: updateRecipe のユニットテスト8件追加
  - 未認証 → /login リダイレクト
  - 他人のレシピ → / リダイレクト
  - 成功時 → $transaction 呼び出し、/recipes/:id リダイレクト
  - servings/cookTime の数値変換・null変換
  - 空材料・空手順のフィルタリング
  - カテゴリの upsert
- app/recipes/[id]/edit/page.test.tsx （新規）: EditRecipeForm のコンポーネントテスト8件
  - セクション表示確認
  - initialValues のフォーム反映
  - バリデーション（タイトル必須）
  - 送信時の updateRecipe 呼び出し
  - 材料・手順・カテゴリの追加・削除

## やらないこと
<!-- このPRでやらないことは何か -->
- なし

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
