### PR TITLE
【feature/22】レシピ本から自動抽出機能実装

### DIFF
--- a/app/api/images/convert/route.test.ts
+++ b/app/api/images/convert/route.test.ts
@@ -41,8 +41,8 @@ describe('POST /api/images/convert', () => {
     const res = await POST(makeFormData(file) as unknown as Request)
 
     expect(mockHeicTo).not.toHaveBeenCalled()
-    expect(mockSharpInstance.resize).toHaveBeenCalledWith(1920, 1920, { fit: 'inside', withoutEnlargement: true })
-    expect(mockSharpInstance.jpeg).toHaveBeenCalledWith({ quality: 85 })
+    expect(mockSharpInstance.resize).toHaveBeenCalledWith(1024, 1024, { fit: 'inside', withoutEnlargement: true })
+    expect(mockSharpInstance.jpeg).toHaveBeenCalledWith({ quality: 70 })
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('image/jpeg')
   })

--- a/app/api/images/convert/route.ts
+++ b/app/api/images/convert/route.ts
@@ -28,8 +28,8 @@ export async function POST(req: NextRequest) {
     }
 
     const jpegBuffer = await sharp(buffer)
-      .resize(1920, 1920, { fit: 'inside', withoutEnlargement: true })
-      .jpeg({ quality: 85 })
+      .resize(1024, 1024, { fit: 'inside', withoutEnlargement: true })
+      .jpeg({ quality: 70 })
       .toBuffer()
 
     return new NextResponse(new Uint8Array(jpegBuffer), {

--- a/app/api/recipes/parse/route.test.ts
+++ b/app/api/recipes/parse/route.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ParsedRecipe } from '../../../types/recipe'
+
+const { mockGetUser, mockGenerateContent } = vi.hoisted(() => {
+  const mockGetUser = vi.fn()
+  const mockGenerateContent = vi.fn()
+  return { mockGetUser, mockGenerateContent }
+})
+
+vi.mock('../../../utils/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}))
+
+vi.mock('@google/generative-ai', () => {
+  function GoogleGenerativeAI() {
+    return {
+      getGenerativeModel: vi.fn().mockReturnValue({
+        generateContent: mockGenerateContent,
+      }),
+    }
+  }
+  return { GoogleGenerativeAI }
+})
+
+import { POST } from './route'
+
+function makeRequest(file?: File) {
+  const formData = new FormData()
+  if (file) formData.append('image', file)
+  return new Request('http://localhost/api/recipes/parse', {
+    method: 'POST',
+    body: formData,
+  })
+}
+
+const validParsedRecipe: ParsedRecipe = {
+  title: 'カレーライス',
+  description: '定番カレー',
+  servings: 4,
+  cookTime: 30,
+  ingredients: [{ name: '玉ねぎ', amount: '1', unit: '個' }],
+  steps: ['玉ねぎを炒める', 'カレールーを加える'],
+}
+
+describe('POST /api/recipes/parse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } } })
+  })
+
+  it('未認証の場合は 401 を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    const res = await POST(makeRequest(file) as unknown as Request)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('image フィールドがない場合は 400 を返す', async () => {
+    const res = await POST(makeRequest() as unknown as Request)
+
+    expect(res.status).toBe(400)
+  })
+
+  it('Gemini が正しい JSON を返す場合は 200 + ParsedRecipe を返す', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => JSON.stringify(validParsedRecipe) },
+    })
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    const res = await POST(makeRequest(file) as unknown as Request)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual(validParsedRecipe)
+  })
+
+  it('Gemini が部分的な JSON (一部 null) を返す場合は 200 で null フィールドあり', async () => {
+    const partial: ParsedRecipe = {
+      title: null,
+      description: null,
+      servings: null,
+      cookTime: null,
+      ingredients: [],
+      steps: [],
+    }
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => JSON.stringify(partial) },
+    })
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    const res = await POST(makeRequest(file) as unknown as Request)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.title).toBeNull()
+    expect(body.servings).toBeNull()
+  })
+
+  it('Gemini が invalid JSON を返す場合は 500 を返す', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => 'これはJSONではない' },
+    })
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    const res = await POST(makeRequest(file) as unknown as Request)
+
+    expect(res.status).toBe(500)
+  })
+
+  it('Gemini API が例外を投げる場合は 500 を返す', async () => {
+    mockGenerateContent.mockRejectedValue(new Error('API error'))
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    const res = await POST(makeRequest(file) as unknown as Request)
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/recipes/parse/route.ts
+++ b/app/api/recipes/parse/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import { createClient } from '../../../utils/supabase/server'
+
+const PROMPT = `この画像はレシピ本のページです。画像からレシピ情報を抽出し、以下のJSON形式のみで出力してください。
+マークダウンや説明文は不要です。JSONのみを返してください。
+
+{
+  "title": "レシピのタイトル（見つからない場合はnull）",
+  "description": "レシピの説明や概要（見つからない場合はnull）",
+  "servings": 人数を表す整数（見つからない場合はnull）,
+  "cookTime": 調理時間を分単位の整数（見つからない場合はnull）,
+  "ingredients": [
+    { "name": "材料名", "amount": "量", "unit": "単位" }
+  ],
+  "steps": ["手順1の説明", "手順2の説明"]
+}
+
+材料の量と単位が分離できない場合（例:「適量」）は amount にそのまま入れ unit は空文字にしてください。
+手順は配列の順序通りに並べてください。`
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const formData = await req.formData()
+    const image = formData.get('image')
+    if (!image || !(image instanceof File)) {
+      return NextResponse.json({ error: 'No image provided' }, { status: 400 })
+    }
+
+    const arrayBuffer = await image.arrayBuffer()
+    const base64 = Buffer.from(arrayBuffer).toString('base64')
+
+    const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GENERATIVE_AI_API_KEY!)
+    const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' })
+
+    const result = await model.generateContent([
+      PROMPT,
+      { inlineData: { mimeType: image.type || 'image/jpeg', data: base64 } },
+    ])
+
+    const text = result.response.text().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim()
+    const parsed = JSON.parse(text)
+
+    return NextResponse.json(parsed, { status: 200 })
+  } catch (err) {
+    console.error('Recipe parse error:', err)
+    return NextResponse.json({ error: 'Failed to parse recipe' }, { status: 500 })
+  }
+}

--- a/app/components/AddRecipeDropdown.tsx
+++ b/app/components/AddRecipeDropdown.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
+import Link from 'next/link'
+
+export default function AddRecipeDropdown() {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="px-4 py-2 rounded-lg bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 transition-colors flex items-center gap-1"
+      >
+        + レシピを追加
+        <span className="text-xs">▾</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 w-44 rounded-lg bg-white border border-zinc-200 shadow-lg z-10 overflow-hidden">
+          <Link
+            href="/recipes/new"
+            onClick={() => setOpen(false)}
+            className="block px-4 py-3 text-sm text-zinc-700 hover:bg-zinc-50 transition-colors"
+          >
+            手動で作成
+          </Link>
+          <Link
+            href="/recipes/new/from-photo"
+            onClick={() => setOpen(false)}
+            className="block px-4 py-3 text-sm text-zinc-700 hover:bg-zinc-50 transition-colors border-t border-zinc-100"
+          >
+            写真から作成
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { signOut } from './(auth)/actions'
 import { createClient } from './utils/supabase/server'
 import { prisma } from '../lib/prisma'
+import AddRecipeDropdown from './components/AddRecipeDropdown'
 
 export default async function Home() {
   const supabase = await createClient()
@@ -37,12 +38,7 @@ export default async function Home() {
       <main className="max-w-3xl mx-auto px-4 py-8">
         <div className="flex items-center justify-between mb-6">
           <p className="text-sm text-zinc-500">{recipes.length}件のレシピ</p>
-          <Link
-            href="/recipes/new"
-            className="px-4 py-2 rounded-lg bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 transition-colors"
-          >
-            + レシピを追加
-          </Link>
+          <AddRecipeDropdown />
         </div>
 
         {recipes.length === 0 ? (

--- a/app/recipes/new/from-photo/page.test.tsx
+++ b/app/recipes/new/from-photo/page.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ParsedRecipe } from '../../../types/recipe'
+
+const { mockParseRecipe, mockCreateRecipe, mockRouterBack, mockConvertImage } = vi.hoisted(() => ({
+  mockParseRecipe: vi.fn(),
+  mockCreateRecipe: vi.fn(),
+  mockRouterBack: vi.fn(),
+  mockConvertImage: vi.fn(),
+}))
+
+vi.mock('../../../utils/recipeParser', () => ({
+  parseRecipeFromImage: mockParseRecipe,
+}))
+
+vi.mock('../../actions', () => ({
+  createRecipe: mockCreateRecipe,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: mockRouterBack }),
+}))
+
+vi.mock('../../../utils/imageConverter', () => ({
+  convertImage: mockConvertImage,
+}))
+
+vi.mock('../../../utils/supabase/client', () => ({
+  createClient: vi.fn().mockReturnValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }) },
+    storage: {
+      from: vi.fn().mockReturnValue({
+        upload: vi.fn().mockResolvedValue({ data: {}, error: null }),
+        getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://example.com/image.jpg' } }),
+      }),
+    },
+  }),
+}))
+
+import FromPhotoPage from './page'
+
+const validRecipe: ParsedRecipe = {
+  title: 'カレーライス',
+  description: '定番カレー',
+  servings: 4,
+  cookTime: 30,
+  ingredients: [{ name: '玉ねぎ', amount: '1', unit: '個' }],
+  steps: ['玉ねぎを炒める', 'カレールーを加える'],
+}
+
+describe('FromPhotoPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConvertImage.mockImplementation((file: File) =>
+      Promise.resolve({ convertedFile: file, previewUrl: 'blob:mock' })
+    )
+    mockParseRecipe.mockResolvedValue(validRecipe)
+  })
+
+  it('初期表示では写真アップロードエリアのみ表示', () => {
+    render(<FromPhotoPage />)
+
+    expect(screen.getByText('タップして写真を選択')).toBeInTheDocument()
+  })
+
+  it('画像選択後にプレビューが表示される', async () => {
+    const user = userEvent.setup()
+    render(<FromPhotoPage />)
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await user.upload(screen.getByLabelText('写真を選択'), file)
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: 'プレビュー' })).toBeInTheDocument()
+    })
+  })
+
+  it('画像選択後に自動で parseRecipeFromImage が呼ばれ、フォームに自動入力される', async () => {
+    const user = userEvent.setup()
+    render(<FromPhotoPage />)
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await user.upload(screen.getByLabelText('写真を選択'), file)
+
+    await waitFor(() => {
+      expect(mockParseRecipe).toHaveBeenCalled()
+      expect(screen.getByDisplayValue('カレーライス')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('定番カレー')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('4')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('30')).toBeInTheDocument()
+    })
+  })
+
+  it('解析中は "AI解析中..." が表示される', async () => {
+    const user = userEvent.setup()
+    let resolvePromise!: (v: ParsedRecipe) => void
+    mockParseRecipe.mockReturnValue(new Promise<ParsedRecipe>((resolve) => { resolvePromise = resolve }))
+    render(<FromPhotoPage />)
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await user.upload(screen.getByLabelText('写真を選択'), file)
+
+    await waitFor(() => {
+      expect(screen.getByText('画像読み取り中・・・')).toBeInTheDocument()
+    })
+
+    resolvePromise(validRecipe)
+  })
+
+  it('解析失敗時にエラーメッセージが表示される', async () => {
+    const user = userEvent.setup()
+    mockParseRecipe.mockRejectedValue(new Error('parse failed'))
+    render(<FromPhotoPage />)
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await user.upload(screen.getByLabelText('写真を選択'), file)
+
+    await waitFor(() => {
+      expect(screen.getByText(/解析に失敗しました/)).toBeInTheDocument()
+    })
+  })
+
+  it('null フィールドがある場合は既存入力を上書きしない', async () => {
+    const user = userEvent.setup()
+    const partial: ParsedRecipe = {
+      title: null,
+      description: null,
+      servings: null,
+      cookTime: null,
+      ingredients: [],
+      steps: [],
+    }
+    mockParseRecipe.mockResolvedValue(partial)
+    render(<FromPhotoPage />)
+
+    await user.type(screen.getByPlaceholderText('例: 肉じゃが'), '手動タイトル')
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await user.upload(screen.getByLabelText('写真を選択'), file)
+
+    await waitFor(() => expect(mockParseRecipe).toHaveBeenCalled())
+    expect(screen.getByDisplayValue('手動タイトル')).toBeInTheDocument()
+  })
+
+  it('解析完了後も手動で編集できる', async () => {
+    const user = userEvent.setup()
+    render(<FromPhotoPage />)
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await user.upload(screen.getByLabelText('写真を選択'), file)
+
+    await waitFor(() => screen.getByDisplayValue('カレーライス'))
+    const titleInput = screen.getByDisplayValue('カレーライス')
+    await user.clear(titleInput)
+    await user.type(titleInput, '編集後タイトル')
+
+    expect(screen.getByDisplayValue('編集後タイトル')).toBeInTheDocument()
+  })
+})

--- a/app/recipes/new/from-photo/page.tsx
+++ b/app/recipes/new/from-photo/page.tsx
@@ -1,0 +1,383 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { isRedirectError } from 'next/dist/client/components/redirect-error'
+import { createRecipe, type IngredientInput, type StepInput } from '../../actions'
+import { createClient } from '../../../utils/supabase/client'
+import { convertImage } from '../../../utils/imageConverter'
+import { parseRecipeFromImage } from '../../../utils/recipeParser'
+
+export default function FromPhotoPage() {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [servings, setServings] = useState('')
+  const [cookTime, setCookTime] = useState('')
+  const [ingredients, setIngredients] = useState<IngredientInput[]>([
+    { name: '', amount: '', unit: '' },
+  ])
+  const [steps, setSteps] = useState<StepInput[]>([{ description: '' }])
+  const [categoryInput, setCategoryInput] = useState('')
+  const [categories, setCategories] = useState<string[]>([])
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const [isParsing, setIsParsing] = useState(false)
+  const [parseError, setParseError] = useState<string | null>(null)
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (file.size > 10 * 1024 * 1024) {
+      setUploadError('ファイルサイズは10MB以下にしてください。')
+      return
+    }
+    setUploadError(null)
+    setParseError(null)
+    let convertedFile: File
+    try {
+      const result = await convertImage(file)
+      convertedFile = result.convertedFile
+      setImageFile(convertedFile)
+      setImagePreviewUrl(result.previewUrl)
+    } catch {
+      setUploadError('画像の変換に失敗しました。もう一度お試しください。')
+      return
+    }
+    setIsParsing(true)
+    try {
+      const parsed = await parseRecipeFromImage(convertedFile)
+      if (parsed.title !== null) setTitle(parsed.title)
+      if (parsed.description !== null) setDescription(parsed.description)
+      if (parsed.servings !== null) setServings(String(parsed.servings))
+      if (parsed.cookTime !== null) setCookTime(String(parsed.cookTime))
+      if (parsed.ingredients.length > 0) setIngredients(parsed.ingredients)
+      if (parsed.steps.length > 0) setSteps(parsed.steps.map((s) => ({ description: s })))
+    } catch {
+      setParseError('解析に失敗しました。もう一度お試しください。')
+    } finally {
+      setIsParsing(false)
+    }
+  }
+
+  const clearImage = () => {
+    setImageFile(null)
+    setImagePreviewUrl(null)
+    setUploadError(null)
+    setParseError(null)
+  }
+
+  const addIngredient = () =>
+    setIngredients((prev) => [...prev, { name: '', amount: '', unit: '' }])
+  const removeIngredient = (index: number) =>
+    setIngredients((prev) => prev.filter((_, i) => i !== index))
+  const updateIngredient = (index: number, field: keyof IngredientInput, value: string) =>
+    setIngredients((prev) =>
+      prev.map((ing, i) => (i === index ? { ...ing, [field]: value } : ing))
+    )
+
+  const addStep = () => setSteps((prev) => [...prev, { description: '' }])
+  const removeStep = (index: number) =>
+    setSteps((prev) => prev.filter((_, i) => i !== index))
+  const updateStep = (index: number, value: string) =>
+    setSteps((prev) =>
+      prev.map((step, i) => (i === index ? { description: value } : step))
+    )
+
+  const addCategory = () => {
+    const trimmed = categoryInput.trim()
+    if (!trimmed || categories.includes(trimmed)) return
+    setCategories((prev) => [...prev, trimmed])
+    setCategoryInput('')
+  }
+  const removeCategory = (name: string) =>
+    setCategories((prev) => prev.filter((c) => c !== name))
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) {
+      setError('タイトルを入力してください。')
+      return
+    }
+    setError(null)
+    startTransition(async () => {
+      try {
+        let imageUrl: string | undefined
+        if (imageFile) {
+          const supabase = createClient()
+          const { data: { user } } = await supabase.auth.getUser()
+          if (!user) {
+            setUploadError('セッションが切れました。再ログインしてください。')
+            return
+          }
+          const path = `${user.id}/${crypto.randomUUID()}.jpg`
+          const { error: uploadErr } = await supabase.storage.from('recipe-images').upload(path, imageFile)
+          if (uploadErr) {
+            console.error('Storageアップロードエラー:', uploadErr)
+            setUploadError(`写真のアップロードに失敗しました。(${uploadErr.message})`)
+            return
+          }
+          const { data: { publicUrl } } = supabase.storage.from('recipe-images').getPublicUrl(path)
+          imageUrl = publicUrl
+        }
+        await createRecipe({ title, description, servings, cookTime, ingredients, steps, categories, imageUrl })
+      } catch (err) {
+        if (isRedirectError(err)) throw err
+        console.error('保存エラー:', err)
+        setError('保存に失敗しました。もう一度お試しください。')
+      }
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50">
+      <header className="bg-white border-b border-zinc-200">
+        <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors"
+          >
+            ← 戻る
+          </button>
+          <h1 className="text-lg font-semibold text-zinc-900">写真からレシピを作成</h1>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-8">
+        <form onSubmit={handleSubmit} className="space-y-8">
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+              {error}
+            </p>
+          )}
+
+          {/* 写真 */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">写真</h2>
+            {uploadError && (
+              <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+                {uploadError}
+              </p>
+            )}
+            {imagePreviewUrl ? (
+              <div className="space-y-3">
+                <div className="w-full aspect-video rounded-lg overflow-hidden bg-zinc-100">
+                  <img src={imagePreviewUrl} alt="プレビュー" className="w-full h-full object-cover" />
+                </div>
+                {isParsing && (
+                  <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
+                    <svg className="animate-spin h-4 w-4 text-zinc-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    画像読み取り中・・・
+                  </div>
+                )}
+                {parseError && (
+                  <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+                    {parseError}
+                  </p>
+                )}
+                <button
+                  type="button"
+                  onClick={clearImage}
+                  className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors"
+                >
+                  写真を削除
+                </button>
+              </div>
+            ) : (
+              <label className="flex flex-col items-center justify-center w-full h-32 rounded-lg border-2 border-dashed border-zinc-300 cursor-pointer hover:border-zinc-400 transition-colors">
+                <span className="text-sm text-zinc-500">タップして写真を選択</span>
+                <input
+                  type="file"
+                  accept="image/*"
+                  aria-label="写真を選択"
+                  className="sr-only"
+                  onChange={handleImageChange}
+                />
+              </label>
+            )}
+          </section>
+
+          {/* 基本情報 */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">基本情報</h2>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 mb-1">
+                タイトル <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-600">必須</span>
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="例: 肉じゃが"
+                className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 mb-1">説明・メモ <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="レシピの概要や備考など"
+                rows={3}
+                className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 resize-none"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">人数 <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    min="1"
+                    value={servings}
+                    onChange={(e) => setServings(e.target.value)}
+                    placeholder="2"
+                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 pr-8"
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-zinc-400">人</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">調理時間 <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    min="1"
+                    value={cookTime}
+                    onChange={(e) => setCookTime(e.target.value)}
+                    placeholder="30"
+                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 pr-10"
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-zinc-400">分</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* カテゴリ */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">カテゴリ <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></h2>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={categoryInput}
+                onChange={(e) => setCategoryInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCategory() } }}
+                placeholder="例: 和食、夕食、お弁当"
+                className="flex-1 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+              />
+              <button
+                type="button"
+                onClick={addCategory}
+                className="px-4 py-2 text-sm font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 transition-colors"
+              >
+                追加
+              </button>
+            </div>
+            {categories.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {categories.map((cat) => (
+                  <span key={cat} className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm bg-zinc-100 text-zinc-700">
+                    {cat}
+                    <button type="button" onClick={() => removeCategory(cat)} className="text-zinc-400 hover:text-zinc-700 transition-colors leading-none">×</button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* 材料 */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">材料 <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></h2>
+            <div className="space-y-2">
+              {ingredients.map((ing, index) => (
+                <div key={index} className="flex gap-2 items-center">
+                  <input
+                    type="text"
+                    value={ing.name}
+                    onChange={(e) => updateIngredient(index, 'name', e.target.value)}
+                    placeholder="材料名"
+                    className="flex-1 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+                  />
+                  <input
+                    type="text"
+                    value={ing.amount}
+                    onChange={(e) => updateIngredient(index, 'amount', e.target.value)}
+                    placeholder="量"
+                    className="w-20 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+                  />
+                  <input
+                    type="text"
+                    value={ing.unit}
+                    onChange={(e) => updateIngredient(index, 'unit', e.target.value)}
+                    placeholder="単位"
+                    className="w-20 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+                  />
+                  {ingredients.length > 1 && (
+                    <button type="button" onClick={() => removeIngredient(index)} className="text-zinc-400 hover:text-red-500 transition-colors text-lg leading-none">×</button>
+                  )}
+                </div>
+              ))}
+            </div>
+            <button type="button" onClick={addIngredient} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+              + 材料を追加
+            </button>
+          </section>
+
+          {/* 手順 */}
+          <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-zinc-900">手順 <span className="ml-1 px-1.5 py-0.5 rounded text-xs font-medium bg-zinc-100 text-zinc-500">任意</span></h2>
+            <div className="space-y-3">
+              {steps.map((step, index) => (
+                <div key={index} className="flex gap-3 items-start">
+                  <span className="mt-2.5 flex-shrink-0 w-6 h-6 rounded-full bg-zinc-900 text-white text-xs flex items-center justify-center font-medium">
+                    {index + 1}
+                  </span>
+                  <textarea
+                    value={step.description}
+                    onChange={(e) => updateStep(index, e.target.value)}
+                    placeholder={`手順 ${index + 1}`}
+                    rows={2}
+                    className="flex-1 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 resize-none"
+                  />
+                  {steps.length > 1 && (
+                    <button type="button" onClick={() => removeStep(index)} className="mt-2.5 text-zinc-400 hover:text-red-500 transition-colors text-lg leading-none">×</button>
+                  )}
+                </div>
+              ))}
+            </div>
+            <button type="button" onClick={addStep} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+              + 手順を追加
+            </button>
+          </section>
+
+          {/* 送信 */}
+          <div className="flex gap-3 pb-8">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="flex-1 py-3 rounded-xl border border-zinc-300 text-sm font-medium text-zinc-700 hover:bg-zinc-50 transition-colors"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isPending}
+              className="flex-1 py-3 rounded-xl bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isPending ? '保存中...' : 'レシピを保存'}
+            </button>
+          </div>
+        </form>
+      </main>
+    </div>
+  )
+}

--- a/app/types/recipe.ts
+++ b/app/types/recipe.ts
@@ -1,0 +1,14 @@
+export type ParsedIngredient = {
+  name: string
+  amount: string
+  unit: string
+}
+
+export type ParsedRecipe = {
+  title: string | null
+  description: string | null
+  servings: number | null
+  cookTime: number | null
+  ingredients: ParsedIngredient[]
+  steps: string[]
+}

--- a/app/utils/recipeParser.ts
+++ b/app/utils/recipeParser.ts
@@ -1,0 +1,14 @@
+import type { ParsedRecipe } from '../types/recipe'
+
+export async function parseRecipeFromImage(file: File): Promise<ParsedRecipe> {
+  const formData = new FormData()
+  formData.append('image', file)
+
+  const res = await fetch('/api/recipes/parse', { method: 'POST', body: formData })
+
+  if (!res.ok) {
+    throw new Error('Failed to parse recipe')
+  }
+
+  return res.json()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pocket-recipe",
       "version": "0.1.0",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "@prisma/adapter-pg": "^7.4.1",
         "@prisma/client": "^7.4.1",
         "@supabase/ssr": "^0.8.0",
@@ -1030,6 +1031,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
     "@supabase/ssr": "^0.8.0",


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
レシピ本の写真を撮影・アップロードすると Gemini 2.5 Flash が自動でレシピ情報を解析し、フォームに自動入力する機能を追加した。

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #22 

## やったこと
<!-- このPRで何をしたのか -->
- POST /api/recipes/parse を新設
  - Supabase で認証確認
  - 画像を base64 変換して Gemini 2.5 Flash に送信
  - JSON でレシピ情報（タイトル・説明・人数・調理時間・材料・手順）を返す
- /recipes/new/from-photo ページを新設
  - 画像選択と同時に自動解析開始（ボタン操作不要）
  - 解析中はスピナー＋「画像読み取り中・・・」を表示
  - 解析結果は null フィールドを上書きしない安全なマージ
  - 解析後も手動編集可能
- レシピ一覧ページの「+ レシピを追加」をドロップダウンに変更
  - 「手動で作成」→ /recipes/new
  - 「写真から作成」→ /recipes/new/from-photo
- 画像変換サイズを 1920px→1024px、quality 85→70 に変更し解析速度を改善
- @google/generative-ai パッケージを追加

## やらないこと
<!-- このPRでやらないことは何か -->
- URL・手動入力以外の取り込み方式（今回は写真のみ）
- 解析精度のチューニング（プロンプト改善は別途）

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
- GOOGLE_GENERATIVE_AI_API_KEY を .env.local に設定が必要
- Gemini がまれにコードブロック付きで JSON を返すため、除去処理を実装済み
