### PR TITLE
【feature/36】Vercel 実行時に Chromium をダウンロードして使用する修正

### DIFF
--- a/app/api/recipes/parse-url/route.ts
+++ b/app/api/recipes/parse-url/route.ts
@@ -2,13 +2,16 @@ import { NextRequest, NextResponse } from 'next/server'
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import { createClient } from '../../../utils/supabase/server'
 
+const CHROMIUM_REMOTE_URL =
+  'https://github.com/Sparticuz/chromium/releases/download/v143.0.0/chromium-v143.0.0-pack.tar'
+
 async function launchBrowser() {
   if (process.env.VERCEL) {
-    const chromium = await import('@sparticuz/chromium')
+    const chromium = await import('@sparticuz/chromium-min')
     const puppeteerCore = await import('puppeteer-core')
     return puppeteerCore.default.launch({
       args: chromium.default.args,
-      executablePath: await chromium.default.executablePath(),
+      executablePath: await chromium.default.executablePath(CHROMIUM_REMOTE_URL),
       headless: true,
     })
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@google/generative-ai": "^0.24.1",
         "@prisma/adapter-pg": "^7.4.1",
         "@prisma/client": "^7.4.1",
-        "@sparticuz/chromium": "^143.0.4",
+        "@sparticuz/chromium-min": "^143.0.4",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.97.0",
         "@types/pg": "^8.16.0",
@@ -2410,10 +2410,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sparticuz/chromium": {
+    "node_modules/@sparticuz/chromium-min": {
       "version": "143.0.4",
-      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-143.0.4.tgz",
-      "integrity": "sha512-/6I7uQTRhRDD2/gGPQ1Gkf+Dqk0RYDACPJDZfSzz0OWk4JmUTonNHPXbrn6UIklOHlnDLf8xAAzkOZKB/cJpLA==",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium-min/-/chromium-min-143.0.4.tgz",
+      "integrity": "sha512-vAV731SUEVH0FUmMc+404ZoRq0glq7DlhEGpAX0C7/rXupZ0HasOIJHbrjNNNE+VElenkdmwBm8MVTzwYcFPyQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@google/generative-ai": "^0.24.1",
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
-    "@sparticuz/chromium": "^143.0.4",
+    "@sparticuz/chromium-min": "^143.0.4",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.97.0",
     "@types/pg": "^8.16.0",


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
@sparticuz/chromium が動かなかった
@sparticuz/chromium-min はバイナリをパッケージに含めない代わりに、executablePath(url) に外部 URL を渡すと実行時にその場でダウンロード・展開するため、そのように修正

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #32 
- #34 
- #36

## やったこと
<!-- このPRで何をしたのか -->
- @sparticuz/chromium → @sparticuz/chromium-min に変更
  - -min はバイナリをパッケージに同梱せず、実行時に外部 URL から取得する軽量版
- executablePath() に GitHub Releases の tar URL を渡すことで、Vercel 実行時に Chromium をダウンロードして使用する

## やらないこと
<!-- このPRでやらないことは何か -->
- なし

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
