### PR TITLE
Chromiumのtarファイルバージョンを修正

### DIFF
--- a/app/api/recipes/parse-url/route.ts
+++ b/app/api/recipes/parse-url/route.ts
@@ -3,7 +3,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai'
 import { createClient } from '../../../utils/supabase/server'
 
 const CHROMIUM_REMOTE_URL =
-  'https://github.com/Sparticuz/chromium/releases/download/v143.0.0/chromium-v143.0.0-pack.tar'
+  'https://github.com/Sparticuz/chromium/releases/download/v143.0.4/chromium-v143.0.4-pack.x64.tar'
 
 async function launchBrowser() {
   if (process.env.VERCEL) {


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
GitHub Releases からChromiumのtar ファイルをダウンロードしようとして404エラーとなっていた

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #33 
- #34 
- #36 
- #38 

## やったこと
<!-- このPRで何をしたのか -->
- v143.0.0 以降、アーキテクチャ別（x64 / arm64）に分離されたため、以前の -pack.tar という URL が 404 になっていた。Vercel は x64 Linux なのでpack.x64.tar を指定した
- パッケージバージョン 143.0.4 に合わせて v143.0.4 とした

## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
