### PR TITLE
【feature/44】UIの修正

### DIFF
--- a/app/calendar/[date]/MealDateClient.tsx
+++ b/app/calendar/[date]/MealDateClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useTransition, useMemo } from 'react'
+import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { createMealRecord, deleteMealRecord } from '../../meal-records/actions'
@@ -11,6 +12,7 @@ type Recipe = {
   description: string | null
   servings: number | null
   cookTime: number | null
+  imageUrl: string | null
   categories: Array<{ category: { id: string; name: string } }>
 }
 
@@ -57,60 +59,87 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
     <div className="space-y-6">
       {/* 登録済みレシピ */}
       <section>
-        <h2 className="text-sm font-medium text-zinc-500 mb-2">登録済み</h2>
+        <h2 className="text-sm font-medium text-zinc-500 mb-3">登録済み</h2>
         {mealRecords.length === 0 ? (
           <p className="text-sm text-zinc-400">まだ登録されていません</p>
         ) : (
-          <ul className="space-y-2">
-            {mealRecords.map((r) => (
-              <li key={r.id} data-testid={`registered-${r.recipeId}`} className="flex items-center justify-between bg-white rounded-lg border border-zinc-200 px-4 py-3">
-                <Link
-                  href={`/recipes/${r.recipeId}`}
-                  className="text-sm font-medium text-zinc-900 hover:underline"
-                >
-                  {r.recipe.title}
-                </Link>
-                <button
-                  type="button"
-                  aria-label="削除"
-                  disabled={isPending}
-                  onClick={() => handleDelete(r.id)}
-                  className="text-xs text-red-500 hover:text-red-700 disabled:opacity-50"
-                >
-                  削除
-                </button>
-              </li>
-            ))}
+          <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+            {mealRecords.map((r) => {
+              const recipe = recipes.find((re) => re.id === r.recipeId)
+              return (
+                <li key={r.id} data-testid={`registered-${r.recipeId}`} className="relative group">
+                  <Link
+                    href={`/recipes/${r.recipeId}`}
+                    className="flex flex-col bg-white rounded-xl border border-zinc-200 hover:border-zinc-400 transition-colors overflow-hidden h-full"
+                  >
+                    {recipe?.imageUrl ? (
+                      <div className="relative aspect-square w-full">
+                        <Image src={recipe.imageUrl} alt={r.recipe.title} fill className="object-cover" sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw" />
+                      </div>
+                    ) : (
+                      <div className="aspect-square w-full bg-zinc-100 flex items-center justify-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-zinc-300"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>
+                      </div>
+                    )}
+                    <div className="p-3">
+                      <p className="font-medium text-zinc-900 text-sm leading-snug line-clamp-2">{r.recipe.title}</p>
+                    </div>
+                  </Link>
+                  <button
+                    type="button"
+                    aria-label="削除"
+                    disabled={isPending}
+                    onClick={() => handleDelete(r.id)}
+                    className="absolute top-2 right-2 w-6 h-6 flex items-center justify-center rounded-full bg-white/90 text-red-500 hover:text-red-700 text-xs shadow disabled:opacity-50 cursor-pointer"
+                  >
+                    ✕
+                  </button>
+                </li>
+              )
+            })}
           </ul>
         )}
       </section>
 
       {/* レシピを追加 */}
       <section>
-        <h2 className="text-sm font-medium text-zinc-500 mb-2">レシピを追加</h2>
+        <h2 className="text-sm font-medium text-zinc-500 mb-3">レシピを追加</h2>
         <input
           type="text"
           placeholder="レシピを検索..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className="w-full mb-3 px-3 py-2 text-sm border border-zinc-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-300"
+          className="w-full mb-4 px-3 py-2 text-sm border border-zinc-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-300"
         />
         {filtered.length === 0 ? (
           <p className="text-sm text-zinc-400">該当するレシピがありません</p>
         ) : (
-          <ul className="space-y-2">
+          <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
             {filtered.map((recipe) => (
-              <li key={recipe.id} className="flex items-center justify-between bg-white rounded-lg border border-zinc-200 px-4 py-3">
-                <span className="text-sm text-zinc-700">{recipe.title}</span>
-                <button
-                  type="button"
-                  aria-label="追加"
-                  disabled={isPending}
-                  onClick={() => handleAdd(recipe.id)}
-                  className="text-xs font-medium text-zinc-600 hover:text-zinc-900 disabled:opacity-50"
-                >
-                  追加
-                </button>
+              <li key={recipe.id} className="relative">
+                <div className="flex flex-col bg-white rounded-xl border border-zinc-200 overflow-hidden h-full">
+                  {recipe.imageUrl ? (
+                    <div className="relative aspect-square w-full">
+                      <Image src={recipe.imageUrl} alt={recipe.title} fill className="object-cover" sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw" />
+                    </div>
+                  ) : (
+                    <div className="aspect-square w-full bg-zinc-100 flex items-center justify-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-zinc-300"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>
+                    </div>
+                  )}
+                  <div className="flex items-center justify-between gap-2 p-3">
+                    <p className="text-sm text-zinc-700 leading-snug line-clamp-2 flex-1">{recipe.title}</p>
+                    <button
+                      type="button"
+                      aria-label="追加"
+                      disabled={isPending}
+                      onClick={() => handleAdd(recipe.id)}
+                      className="flex-shrink-0 px-2 py-1 text-xs font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 disabled:opacity-50 cursor-pointer"
+                    >
+                      追加
+                    </button>
+                  </div>
+                </div>
               </li>
             ))}
           </ul>

--- a/app/calendar/[date]/page.tsx
+++ b/app/calendar/[date]/page.tsx
@@ -27,7 +27,15 @@ export default async function CalendarDatePage({ params }: Props) {
     prisma.recipe.findMany({
       where: { userId: user!.id },
       orderBy: { createdAt: 'desc' },
-      include: { categories: { include: { category: true } } },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        servings: true,
+        cookTime: true,
+        imageUrl: true,
+        categories: { include: { category: true } },
+      },
     }),
     prisma.mealRecord.findMany({
       where: {
@@ -42,15 +50,15 @@ export default async function CalendarDatePage({ params }: Props) {
   return (
     <div className="min-h-screen bg-zinc-50">
       <header className="bg-white border-b border-zinc-200">
-        <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-4">
-          <Link href="/" className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center gap-4">
+          <Link href="/?tab=calendar" className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
             ← カレンダーへ
           </Link>
           <h1 className="text-lg font-semibold text-zinc-900">{formatDateLabel(date)}</h1>
         </div>
       </header>
 
-      <main className="max-w-2xl mx-auto px-4 py-8">
+      <main className="max-w-7xl mx-auto px-4 py-8">
         <MealDateClient date={date} recipes={recipes} mealRecords={mealRecords} />
       </main>
     </div>

--- a/app/components/CalendarView.test.tsx
+++ b/app/components/CalendarView.test.tsx
@@ -72,12 +72,12 @@ describe('CalendarView', () => {
     expect(mockRouterPush).toHaveBeenCalledWith('/calendar/2026-03-15')
   })
 
-  it('前月・翌月セルをクリックしても遷移しない', async () => {
+  it('前月・翌月セルをクリックしても遷移する', async () => {
     const user = userEvent.setup()
     // 2026-04-01 は水曜 → 3/29,30,31 が前月セル
     render(<CalendarView mealRecords={[]} recipes={[]} initialMonth={new Date('2026-04-01')} />)
     await user.click(screen.getByTestId('cell-2026-03-31'))
-    expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(mockRouterPush).toHaveBeenCalledWith('/calendar/2026-03-31')
   })
 
   it('前月の末尾日付が薄く表示される（2026年4月表示時、3月末が見える）', () => {

--- a/app/components/CalendarView.tsx
+++ b/app/components/CalendarView.tsx
@@ -129,27 +129,29 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
   const goToNextMonth = () => setCurrentMonth(new Date(year, month + 1, 1))
 
   return (
-    <div>
+    <div className="flex flex-col flex-1 min-h-0">
       {/* Month navigation */}
       <div className="flex items-center justify-between mb-4">
         <button
           type="button"
           aria-label="前月"
           onClick={goToPrevMonth}
-          className="px-3 py-1 text-sm text-zinc-600 hover:text-zinc-900"
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 transition-colors cursor-pointer"
         >
-          ← 前月
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+          前月
         </button>
-        <span className="font-medium text-zinc-900">
+        <span className="font-semibold text-zinc-900">
           {year}年{month + 1}月
         </span>
         <button
           type="button"
           aria-label="翌月"
           onClick={goToNextMonth}
-          className="px-3 py-1 text-sm text-zinc-600 hover:text-zinc-900"
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 transition-colors cursor-pointer"
         >
-          翌月 →
+          翌月
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
         </button>
       </div>
 
@@ -169,7 +171,7 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
       </div>
 
       {/* Calendar grid */}
-      <div className="grid grid-cols-7 gap-px bg-zinc-200 border border-zinc-200 rounded-lg overflow-hidden">
+      <div className="grid grid-cols-7 auto-rows-fr gap-px bg-zinc-200 border border-zinc-200 rounded-lg overflow-hidden flex-1">
         {cells.map((cell) => {
           const dayRecords = cell.isCurrentMonth ? (recordsByDate[cell.dateKey] ?? []) : []
           const dayColor = getDayColor(cell.dayOfWeek, cell.holidayName, cell.isCurrentMonth)
@@ -179,12 +181,8 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
               key={cell.dateKey}
               type="button"
               data-testid={`cell-${cell.dateKey}`}
-              onClick={() => {
-                if (cell.isCurrentMonth) router.push(`/calendar/${cell.dateKey}`)
-              }}
-              className={`bg-white min-h-16 p-1 flex flex-col items-center transition-colors ${
-                cell.isCurrentMonth ? 'hover:bg-zinc-50' : 'cursor-default'
-              }`}
+              onClick={() => router.push(`/calendar/${cell.dateKey}`)}
+              className="bg-white p-1 flex flex-col items-center transition-colors hover:bg-zinc-50 cursor-pointer"
             >
               <span className={`text-xs mb-0.5 ${dayColor}`}>{cell.day}</span>
               {cell.holidayName && (

--- a/app/components/HomeTabs.test.tsx
+++ b/app/components/HomeTabs.test.tsx
@@ -4,6 +4,9 @@ import userEvent from '@testing-library/user-event'
 
 vi.mock('./CalendarView', () => ({ default: () => <div>CalendarView</div> }))
 vi.mock('./RecipeList', () => ({ default: () => <div>RecipeList</div> }))
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}))
 
 import HomeTabs from './HomeTabs'
 

--- a/app/components/HomeTabs.tsx
+++ b/app/components/HomeTabs.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import RecipeList from './RecipeList'
 import CalendarView from './CalendarView'
 
@@ -10,6 +11,7 @@ type Recipe = {
   description: string | null
   servings: number | null
   cookTime: number | null
+  imageUrl: string | null
   categories: Array<{ category: { id: string; name: string } }>
 }
 
@@ -28,15 +30,18 @@ type HomeTabsProps = {
 type Tab = 'list' | 'calendar'
 
 export default function HomeTabs({ recipes, mealRecords }: HomeTabsProps) {
-  const [activeTab, setActiveTab] = useState<Tab>('list')
+  const searchParams = useSearchParams()
+  const [activeTab, setActiveTab] = useState<Tab>(
+    searchParams.get('tab') === 'calendar' ? 'calendar' : 'list'
+  )
 
   return (
-    <div>
+    <div className={`flex flex-col ${activeTab === 'calendar' ? 'flex-1 min-h-0' : ''}`}>
       <div className="flex gap-2 mb-6">
         <button
           type="button"
           onClick={() => setActiveTab('list')}
-          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors cursor-pointer ${
             activeTab === 'list'
               ? 'bg-zinc-900 text-white'
               : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'
@@ -47,7 +52,7 @@ export default function HomeTabs({ recipes, mealRecords }: HomeTabsProps) {
         <button
           type="button"
           onClick={() => setActiveTab('calendar')}
-          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors cursor-pointer ${
             activeTab === 'calendar'
               ? 'bg-zinc-900 text-white'
               : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'
@@ -60,7 +65,7 @@ export default function HomeTabs({ recipes, mealRecords }: HomeTabsProps) {
       {activeTab === 'list' ? (
         <RecipeList recipes={recipes} />
       ) : (
-        <CalendarView mealRecords={mealRecords} recipes={recipes} />
+        <div className="flex flex-col flex-1 min-h-0 overflow-hidden"><CalendarView mealRecords={mealRecords} recipes={recipes} /></div>
       )}
     </div>
   )

--- a/app/components/RecipeList.tsx
+++ b/app/components/RecipeList.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import Link from 'next/link'
 
 type Recipe = {
@@ -6,6 +7,7 @@ type Recipe = {
   description: string | null
   servings: number | null
   cookTime: number | null
+  imageUrl: string | null
   categories: Array<{ category: { id: string; name: string } }>
 }
 
@@ -24,33 +26,49 @@ export default function RecipeList({ recipes }: RecipeListProps) {
   }
 
   return (
-    <ul className="space-y-3">
+    <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
       {recipes.map((recipe) => (
         <li key={recipe.id}>
           <Link
             href={`/recipes/${recipe.id}`}
-            className="block bg-white rounded-xl border border-zinc-200 px-5 py-4 hover:border-zinc-400 transition-colors"
+            className="flex flex-col bg-white rounded-xl border border-zinc-200 hover:border-zinc-400 transition-colors overflow-hidden h-full"
           >
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1 min-w-0">
-                <p className="font-medium text-zinc-900 truncate">{recipe.title}</p>
-                {recipe.description && (
-                  <p className="text-sm text-zinc-500 truncate mt-0.5">{recipe.description}</p>
-                )}
-                {recipe.categories.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 mt-2">
-                    {recipe.categories.map(({ category }) => (
-                      <span key={category.id} className="px-2 py-0.5 rounded-full text-xs bg-zinc-100 text-zinc-600">
-                        {category.name}
-                      </span>
-                    ))}
-                  </div>
-                )}
+            {recipe.imageUrl ? (
+              <div className="relative aspect-square w-full">
+                <Image
+                  src={recipe.imageUrl}
+                  alt={recipe.title}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                />
               </div>
-              <div className="flex-shrink-0 text-xs text-zinc-400 space-y-1 text-right">
-                {recipe.servings && <p>{recipe.servings}人前</p>}
-                {recipe.cookTime && <p>{recipe.cookTime}分</p>}
+            ) : (
+              <div className="aspect-square w-full bg-zinc-100 flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-zinc-300"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>
               </div>
+            )}
+            <div className="flex flex-col flex-1 p-3 gap-1">
+              <p className="font-medium text-zinc-900 text-sm leading-snug line-clamp-2">{recipe.title}</p>
+              {recipe.description && (
+                <p className="text-xs text-zinc-500 line-clamp-2">{recipe.description}</p>
+              )}
+              <div className="flex-1" />
+              {recipe.categories.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {recipe.categories.map(({ category }) => (
+                    <span key={category.id} className="px-1.5 py-0.5 rounded-full text-xs bg-zinc-100 text-zinc-600">
+                      {category.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {(recipe.servings || recipe.cookTime) && (
+                <div className="flex gap-2 text-xs text-zinc-400 mt-1">
+                  {recipe.servings && <span>{recipe.servings}人前</span>}
+                  {recipe.cookTime && <span>{recipe.cookTime}分</span>}
+                </div>
+              )}
             </div>
           </Link>
         </li>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { signOut } from './(auth)/actions'
 import { createClient } from './utils/supabase/server'
 import { prisma } from '../lib/prisma'
@@ -12,7 +13,13 @@ export default async function Home() {
     prisma.recipe.findMany({
       where: { userId: user!.id },
       orderBy: { createdAt: 'desc' },
-      include: {
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        servings: true,
+        cookTime: true,
+        imageUrl: true,
         categories: { include: { category: true } },
       },
     }),
@@ -24,9 +31,9 @@ export default async function Home() {
   ])
 
   return (
-    <div className="min-h-screen bg-zinc-50">
+    <div className="min-h-screen flex flex-col bg-zinc-50">
       <header className="bg-white border-b border-zinc-200">
-        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
           <h1 className="text-lg font-semibold text-zinc-900">ぽけっと レシピ</h1>
           <div className="flex items-center gap-4">
             <span className="text-sm text-zinc-500">{user?.email}</span>
@@ -42,13 +49,15 @@ export default async function Home() {
         </div>
       </header>
 
-      <main className="max-w-3xl mx-auto px-4 py-8">
+      <main className="max-w-7xl w-full mx-auto px-4 py-8 flex-1 flex flex-col">
         <div className="flex items-center justify-between mb-6">
           <p className="text-sm text-zinc-500">{recipes.length}件のレシピ</p>
           <AddRecipeDropdown />
         </div>
 
-        <HomeTabs recipes={recipes} mealRecords={mealRecords} />
+        <Suspense>
+          <HomeTabs recipes={recipes} mealRecords={mealRecords} />
+        </Suspense>
       </main>
     </div>
   )

--- a/app/recipes/[id]/BackButton.tsx
+++ b/app/recipes/[id]/BackButton.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export default function BackButton() {
+  const router = useRouter()
+  return (
+    <button
+      type="button"
+      onClick={() => router.back()}
+      className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors cursor-pointer"
+    >
+      ← 戻る
+    </button>
+  )
+}

--- a/app/recipes/[id]/ImageModal.tsx
+++ b/app/recipes/[id]/ImageModal.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+
+type Props = {
+  src: string
+  alt: string
+}
+
+export default function ImageModal({ src, alt }: Props) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="relative lg:w-96 lg:flex-shrink-0 w-full aspect-[4/3] rounded-xl overflow-hidden cursor-zoom-in block"
+      >
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          className="object-cover"
+          sizes="(max-width: 1024px) 100vw, 384px"
+          priority
+        />
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/80 p-4 gap-3"
+          onClick={() => setOpen(false)}
+        >
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="self-end text-white text-sm hover:text-zinc-300 transition-colors cursor-pointer"
+          >
+            閉じる ✕
+          </button>
+          <div className="relative w-full max-w-4xl flex-1 min-h-0" onClick={(e) => e.stopPropagation()}>
+            <Image
+              src={src}
+              alt={alt}
+              fill
+              className="object-contain"
+              sizes="(max-width: 896px) 100vw, 896px"
+            />
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image'
 import { createClient } from '../../utils/supabase/server'
 import { prisma } from '../../../lib/prisma'
 import DeleteButton from './DeleteButton'
+import ImageModal from './ImageModal'
+import BackButton from './BackButton'
 
 type Props = {
   params: Promise<{ id: string }>
@@ -28,11 +30,9 @@ export default async function RecipeDetailPage({ params }: Props) {
   return (
     <div className="min-h-screen bg-zinc-50">
       <header className="bg-white border-b border-zinc-200">
-        <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-4">
-          <Link href="/" className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
-            ← 一覧へ
-          </Link>
-          <h1 className="text-lg font-semibold text-zinc-900 truncate flex-1">{recipe.title}</h1>
+        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center gap-4">
+          <BackButton />
+          <div className="flex-1" />
           <Link
             href={`/recipes/${recipe.id}/edit`}
             className="px-4 py-2 rounded-lg text-sm font-medium text-zinc-700 border border-zinc-200 hover:bg-zinc-50 transition-colors"
@@ -43,84 +43,100 @@ export default async function RecipeDetailPage({ params }: Props) {
         </div>
       </header>
 
-      <main className="max-w-2xl mx-auto px-4 py-8 space-y-6">
-        {recipe.imageUrl && (
-          <section className="bg-white rounded-xl border border-zinc-200 overflow-hidden">
-            <div className="relative w-full aspect-video">
-              <Image
-                src={recipe.imageUrl}
-                alt={recipe.title}
-                fill
-                className="object-cover"
-                sizes="(max-width: 672px) 100vw, 672px"
-              />
-            </div>
-          </section>
-        )}
+      <main className="max-w-7xl mx-auto px-4 py-8 space-y-8">
 
-        <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-3">
-          {recipe.description && (
-            <p className="text-sm text-zinc-600 leading-relaxed">{recipe.description}</p>
+        {/* 上段: 画像 + タイトル・説明 */}
+        <div className="flex flex-col lg:flex-row gap-12">
+          {recipe.imageUrl && (
+            <ImageModal src={recipe.imageUrl} alt={recipe.title} />
           )}
-          <div className="flex gap-4 text-sm text-zinc-500">
-            {recipe.servings && <span>{recipe.servings}人前</span>}
-            {recipe.cookTime && <span>調理時間 {recipe.cookTime}分</span>}
-          </div>
-          {recipe.categories.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {recipe.categories.map(({ category }) => (
-                <span key={category.id} className="px-3 py-1 rounded-full text-xs bg-zinc-100 text-zinc-600">
-                  {category.name}
-                </span>
-              ))}
-            </div>
-          )}
-          {recipe.sourceUrl && (
-            <a
-              href={recipe.sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-600 transition-colors truncate max-w-full"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-              {recipe.sourceUrl}
-            </a>
-          )}
-        </section>
-
-        {recipe.ingredients.length > 0 && (
-          <section className="bg-white rounded-xl border border-zinc-200 p-6">
-            <h2 className="text-base font-semibold text-zinc-900 mb-4">材料</h2>
-            <ul className="space-y-2">
-              {recipe.ingredients.map((ing) => (
-                <li key={ing.id} className="flex justify-between text-sm">
-                  <span className="text-zinc-700">{ing.name}</span>
-                  {(ing.amount || ing.unit) && (
-                    <span className="text-zinc-500">{ing.amount} {ing.unit}</span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-
-        {recipe.steps.length > 0 && (
-          <section className="bg-white rounded-xl border border-zinc-200 p-6">
-            <h2 className="text-base font-semibold text-zinc-900 mb-4">手順</h2>
-            <ol className="space-y-4">
-              {recipe.steps.map((step, index) => (
-                <li key={step.id} className="flex gap-3 items-start">
-                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-zinc-900 text-white text-xs flex items-center justify-center font-medium">
-                    {index + 1}
+          <div className="flex-1 space-y-3">
+            <h1 className="text-4xl font-bold text-zinc-900">{recipe.title}</h1>
+            {recipe.categories.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {recipe.categories.map(({ category }) => (
+                  <span key={category.id} className="px-3 py-1 rounded-full text-xs bg-zinc-100 text-zinc-600">
+                    {category.name}
                   </span>
-                  <p className="text-sm text-zinc-700 leading-relaxed pt-0.5">{step.description}</p>
-                </li>
-              ))}
-            </ol>
-          </section>
-        )}
+                ))}
+              </div>
+            )}
+            {recipe.description && (
+              <p className="text-sm text-zinc-600 leading-relaxed">{recipe.description}</p>
+            )}
+            <div className="flex gap-4 text-sm text-zinc-500">
+              {recipe.cookTime && <span>調理時間 {recipe.cookTime}分</span>}
+            </div>
+            {recipe.sourceUrl && (
+              <a
+                href={recipe.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-600 transition-colors truncate max-w-full"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+                {recipe.sourceUrl}
+              </a>
+            )}
+          </div>
+        </div>
+
+        {/* 下段: 材料 + 作り方 */}
+        <div className="flex flex-col lg:flex-row gap-12 lg:items-start">
+          {/* 材料 */}
+          {recipe.ingredients.length > 0 && (
+            <section className="lg:w-96 lg:flex-shrink-0">
+              <h2 className="text-xl font-bold text-zinc-900 mb-3">材料</h2>
+              {recipe.servings && (
+                <p className="text-sm text-zinc-500 mb-3 flex items-center gap-1">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                  {recipe.servings}人前
+                </p>
+              )}
+              <ul className="divide-y divide-zinc-100">
+                {recipe.ingredients.map((ing) => (
+                  <li key={ing.id} className="flex justify-between py-2 text-sm">
+                    <span className="text-zinc-700">{ing.name}</span>
+                    {(ing.amount || ing.unit) && (
+                      <span className="font-medium text-zinc-900">{ing.amount}{ing.unit}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {/* 作り方 */}
+          {recipe.steps.length > 0 && (
+            <section className="flex-1">
+              <h2 className="text-xl font-bold text-zinc-900 mb-4">作り方</h2>
+              <ol className="grid grid-cols-2 xl:grid-cols-3 gap-6">
+                {recipe.steps.map((step, index) => (
+                  <li key={step.id} className="flex flex-col gap-2">
+                    <span className="flex-shrink-0 w-7 h-7 rounded-full bg-zinc-800 text-white text-sm flex items-center justify-center font-bold">
+                      {index + 1}
+                    </span>
+                    {step.imageUrl && (
+                      <div className="relative w-full aspect-video rounded-lg overflow-hidden">
+                        <Image
+                          src={step.imageUrl}
+                          alt={`手順${index + 1}`}
+                          fill
+                          className="object-cover"
+                          sizes="(max-width: 640px) 100vw, 300px"
+                        />
+                      </div>
+                    )}
+                    <p className="text-sm text-zinc-700 leading-relaxed">{step.description}</p>
+                  </li>
+                ))}
+              </ol>
+            </section>
+          )}
+        </div>
+
       </main>
     </div>
   )


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
ここまでで気になった箇所の修正を行う

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #44 

## やったこと
<!-- このPRで何をしたのか -->
カレンダー画面（一覧画面）

  - カレンダーを画面フルハイトで表示（h-screen + flex チェーン）
  - 横幅を max-w-3xl → max-w-7xl に拡大
  - カレンダーグリッドのセルをホバーでポインターカーソルに変更
  - 当月外のセルもクリック・遷移可能に変更
  - 前月・翌月ボタンをモダンなデザイン（SVG アイコン + 角丸背景）に変更
  - タブ切り替えボタンにポインターカーソルを追加

  レシピ一覧

  - レシピカードにサムネイル画像プレビューを追加
  - レイアウトをリスト形式 → グリッド（タイル）形式に変更（2〜4列レスポンシブ）
  - 画像なしの場合はフォークアイコンのプレースホルダー表示
  - リストがスクロール可能になるよう修正、背景色の見切れを修正

  レシピ詳細画面（/recipes/[id]）

  - 横幅を max-w-2xl → max-w-7xl に拡大
  - 上段：画像（左）＋ タイトル・説明（右）の2カラムレイアウト
  - 下段：材料（左）＋ 作り方（右）の2カラムレイアウト
  - タイトルを text-4xl に拡大、左右の間隔を gap-12 に
  - 作り方を2〜3列グリッド表示
  - 画像クリックでモーダル全体表示（ImageModal コンポーネント）
  - 戻るボタンを router.back() に変更（前の画面に戻る）

  カレンダー日付詳細画面（/calendar/[date]）

  - 横幅を max-w-2xl → max-w-7xl に拡大
  - 登録済みレシピ・追加候補レシピをグリッドカード表示に変更
  - サムネイル画像表示、削除ボタンをカード右上に配置
  - 「← カレンダーへ」が /?tab=calendar に遷移するよう変更

  タブ状態の保持

  - ?tab=calendar クエリパラメータでカレンダータブを初期表示できるよう対応
  - カレンダー日付詳細から戻るとカレンダータブが表示される

## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
