### PR TITLE
【feature/46】カレンダー機能の改善

### DIFF
--- a/app/calendar/[date]/MealDateClient.test.tsx
+++ b/app/calendar/[date]/MealDateClient.test.tsx
@@ -25,13 +25,16 @@ const makeRecipe = (id: string, title: string) => ({
   description: null,
   servings: null,
   cookTime: null,
+  imageUrl: null,
   categories: [] as Array<{ category: { id: string; name: string } }>,
 })
 
-const makeMealRecord = (id: string, recipeId: string, title: string) => ({
+const makeMealRecord = (id: string, recipeId: string, title: string, type = 'ate', mealTime: string | null = null) => ({
   id,
   recipeId,
   date: new Date('2026-03-15'),
+  type,
+  mealTime,
   recipe: { id: recipeId, title },
 })
 
@@ -57,7 +60,7 @@ describe('MealDateClient', () => {
 
   it('登録済みレシピ名をクリックすると /recipes/:id へリンクされている', () => {
     render(<MealDateClient {...defaultProps} mealRecords={[makeMealRecord('m1', 'r1', '肉じゃが')]} />)
-    const link = screen.getByRole('link', { name: '肉じゃが' })
+    const link = screen.getByTestId('registered-r1').querySelector('a')
     expect(link).toHaveAttribute('href', '/recipes/r1')
   })
 
@@ -67,16 +70,6 @@ describe('MealDateClient', () => {
     render(<MealDateClient {...defaultProps} mealRecords={[makeMealRecord('m1', 'r1', '肉じゃが')]} />)
     await user.click(screen.getByRole('button', { name: '削除' }))
     expect(mockDeleteMealRecord).toHaveBeenCalledWith('m1')
-    expect(mockRouterRefresh).toHaveBeenCalled()
-  })
-
-  it('追加ボタンで createMealRecord を呼び refresh する', async () => {
-    const user = userEvent.setup()
-    mockCreateMealRecord.mockResolvedValue(undefined)
-    render(<MealDateClient {...defaultProps} />)
-    const addButtons = screen.getAllByRole('button', { name: '追加' })
-    await user.click(addButtons[0])
-    expect(mockCreateMealRecord).toHaveBeenCalledWith({ recipeId: 'r1', date: '2026-03-15' })
     expect(mockRouterRefresh).toHaveBeenCalled()
   })
 
@@ -93,5 +86,99 @@ describe('MealDateClient', () => {
     render(<MealDateClient {...defaultProps} />)
     await user.type(screen.getByPlaceholderText('レシピを検索...'), 'zzz')
     expect(screen.getByText('該当するレシピがありません')).toBeInTheDocument()
+  })
+
+  it('追加ボタンクリックで「食べた」「作った」の選択肢が表示される', async () => {
+    const user = userEvent.setup()
+    render(<MealDateClient {...defaultProps} />)
+    await user.click(screen.getAllByRole('button', { name: '追加' })[0])
+    expect(screen.getByRole('button', { name: '食べた' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '作った' })).toBeInTheDocument()
+  })
+
+  it('「食べた」選択後に朝/昼/夜の選択肢が表示される', async () => {
+    const user = userEvent.setup()
+    render(<MealDateClient {...defaultProps} />)
+    await user.click(screen.getAllByRole('button', { name: '追加' })[0])
+    await user.click(screen.getByRole('button', { name: '食べた' }))
+    expect(screen.getByRole('button', { name: '朝' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '昼' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '夜' })).toBeInTheDocument()
+  })
+
+  it('「作った」選択後は朝/昼/夜が表示されず直接登録できる', async () => {
+    const user = userEvent.setup()
+    mockCreateMealRecord.mockResolvedValue(undefined)
+    render(<MealDateClient {...defaultProps} />)
+    await user.click(screen.getAllByRole('button', { name: '追加' })[0])
+    await user.click(screen.getByRole('button', { name: '作った' }))
+    expect(screen.queryByRole('button', { name: '朝' })).not.toBeInTheDocument()
+    expect(mockCreateMealRecord).toHaveBeenCalledWith({
+      recipeId: 'r1',
+      date: '2026-03-15',
+      type: 'cooked',
+      mealTime: null,
+    })
+  })
+
+  it('食べた＋昼で登録すると type=ate, mealTime=lunch で呼ばれる', async () => {
+    const user = userEvent.setup()
+    mockCreateMealRecord.mockResolvedValue(undefined)
+    render(<MealDateClient {...defaultProps} />)
+    await user.click(screen.getAllByRole('button', { name: '追加' })[0])
+    await user.click(screen.getByRole('button', { name: '食べた' }))
+    await user.click(screen.getByRole('button', { name: '昼' }))
+    expect(mockCreateMealRecord).toHaveBeenCalledWith({
+      recipeId: 'r1',
+      date: '2026-03-15',
+      type: 'ate',
+      mealTime: 'lunch',
+    })
+    expect(mockRouterRefresh).toHaveBeenCalled()
+  })
+
+  it('食べた＋朝で登録すると type=ate, mealTime=breakfast で呼ばれる', async () => {
+    const user = userEvent.setup()
+    mockCreateMealRecord.mockResolvedValue(undefined)
+    render(<MealDateClient {...defaultProps} />)
+    await user.click(screen.getAllByRole('button', { name: '追加' })[0])
+    await user.click(screen.getByRole('button', { name: '食べた' }))
+    await user.click(screen.getByRole('button', { name: '朝' }))
+    expect(mockCreateMealRecord).toHaveBeenCalledWith({
+      recipeId: 'r1',
+      date: '2026-03-15',
+      type: 'ate',
+      mealTime: 'breakfast',
+    })
+  })
+
+  it('食べた＋夜で登録すると type=ate, mealTime=dinner で呼ばれる', async () => {
+    const user = userEvent.setup()
+    mockCreateMealRecord.mockResolvedValue(undefined)
+    render(<MealDateClient {...defaultProps} />)
+    await user.click(screen.getAllByRole('button', { name: '追加' })[0])
+    await user.click(screen.getByRole('button', { name: '食べた' }))
+    await user.click(screen.getByRole('button', { name: '夜' }))
+    expect(mockCreateMealRecord).toHaveBeenCalledWith({
+      recipeId: 'r1',
+      date: '2026-03-15',
+      type: 'ate',
+      mealTime: 'dinner',
+    })
+  })
+
+  it('登録済みレコードに type=ate, mealTime=lunch で「食べた / 昼」が表示される', () => {
+    render(<MealDateClient {...defaultProps} mealRecords={[makeMealRecord('m1', 'r1', '肉じゃが', 'ate', 'lunch')]} />)
+    expect(screen.getByText('食べた / 昼')).toBeInTheDocument()
+  })
+
+  it('登録済みレコードの type=cooked に「作った」が表示される', () => {
+    render(<MealDateClient {...defaultProps} mealRecords={[makeMealRecord('m1', 'r1', '肉じゃが', 'cooked', null)]} />)
+    expect(screen.getByText('作った')).toBeInTheDocument()
+  })
+
+  it('登録済みレコードの type=ate, mealTime=null に「食べた」が表示される', () => {
+    render(<MealDateClient {...defaultProps} mealRecords={[makeMealRecord('m1', 'r1', '肉じゃが', 'ate', null)]} />)
+    expect(screen.getByText('食べた')).toBeInTheDocument()
   })
 })

--- a/app/calendar/[date]/MealDateClient.tsx
+++ b/app/calendar/[date]/MealDateClient.tsx
@@ -20,6 +20,8 @@ type MealRecord = {
   id: string
   recipeId: string
   date: Date
+  type: string
+  mealTime: string | null
   recipe: { id: string; title: string }
 }
 
@@ -29,10 +31,34 @@ type Props = {
   mealRecords: MealRecord[]
 }
 
+type AddStep =
+  | { phase: 'idle' }
+  | { phase: 'selectType'; recipeId: string }
+  | { phase: 'selectMealTime'; recipeId: string }
+
+const MEAL_TIME_LABELS: Record<string, string> = {
+  breakfast: '朝',
+  lunch: '昼',
+  dinner: '夜',
+}
+
+const MEAL_TIME_VALUES = [
+  { key: 'breakfast', label: '朝' },
+  { key: 'lunch', label: '昼' },
+  { key: 'dinner', label: '夜' },
+]
+
+function getRecordLabel(type: string, mealTime: string | null): string {
+  if (type === 'cooked') return '作った'
+  if (mealTime && MEAL_TIME_LABELS[mealTime]) return `食べた / ${MEAL_TIME_LABELS[mealTime]}`
+  return '食べた'
+}
+
 export default function MealDateClient({ date, recipes, mealRecords }: Props) {
   const router = useRouter()
   const [query, setQuery] = useState('')
   const [isPending, startTransition] = useTransition()
+  const [addStep, setAddStep] = useState<AddStep>({ phase: 'idle' })
 
   const filtered = useMemo(() =>
     query.trim() === ''
@@ -41,11 +67,32 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
     [recipes, query]
   )
 
-  const handleAdd = (recipeId: string) => {
+  const handleAddClick = (recipeId: string) => {
+    setAddStep({ phase: 'selectType', recipeId })
+  }
+
+  const handleSelectType = (type: 'ate' | 'cooked') => {
+    if (addStep.phase !== 'selectType') return
+    const { recipeId } = addStep
+    if (type === 'cooked') {
+      startTransition(async () => {
+        await createMealRecord({ recipeId, date, type: 'cooked', mealTime: null })
+        router.refresh()
+      })
+      setAddStep({ phase: 'idle' })
+    } else {
+      setAddStep({ phase: 'selectMealTime', recipeId })
+    }
+  }
+
+  const handleSelectMealTime = (mealTime: string) => {
+    if (addStep.phase !== 'selectMealTime') return
+    const { recipeId } = addStep
     startTransition(async () => {
-      await createMealRecord({ recipeId, date })
+      await createMealRecord({ recipeId, date, type: 'ate', mealTime })
       router.refresh()
     })
+    setAddStep({ phase: 'idle' })
   }
 
   const handleDelete = (mealRecordId: string) => {
@@ -83,6 +130,7 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
                     )}
                     <div className="p-3">
                       <p className="font-medium text-zinc-900 text-sm leading-snug line-clamp-2">{r.recipe.title}</p>
+                      <p className="text-xs text-zinc-400 mt-1">{getRecordLabel(r.type, r.mealTime)}</p>
                     </div>
                   </Link>
                   <button
@@ -115,33 +163,73 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
           <p className="text-sm text-zinc-400">該当するレシピがありません</p>
         ) : (
           <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-            {filtered.map((recipe) => (
-              <li key={recipe.id} className="relative">
-                <div className="flex flex-col bg-white rounded-xl border border-zinc-200 overflow-hidden h-full">
-                  {recipe.imageUrl ? (
-                    <div className="relative aspect-square w-full">
-                      <Image src={recipe.imageUrl} alt={recipe.title} fill className="object-cover" sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw" />
+            {filtered.map((recipe) => {
+              const isSelected = addStep.phase !== 'idle' && addStep.recipeId === recipe.id
+              return (
+                <li key={recipe.id} className="relative">
+                  <div className="flex flex-col bg-white rounded-xl border border-zinc-200 overflow-hidden h-full">
+                    {recipe.imageUrl ? (
+                      <div className="relative aspect-square w-full">
+                        <Image src={recipe.imageUrl} alt={recipe.title} fill className="object-cover" sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw" />
+                      </div>
+                    ) : (
+                      <div className="aspect-square w-full bg-zinc-100 flex items-center justify-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-zinc-300"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>
+                      </div>
+                    )}
+                    <div className="p-3">
+                      <p className="text-sm text-zinc-700 leading-snug line-clamp-2 mb-2">{recipe.title}</p>
+
+                      {!isSelected && (
+                        <button
+                          type="button"
+                          aria-label="追加"
+                          disabled={isPending}
+                          onClick={() => handleAddClick(recipe.id)}
+                          className="w-full px-2 py-1 text-xs font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 disabled:opacity-50 cursor-pointer"
+                        >
+                          追加
+                        </button>
+                      )}
+
+                      {isSelected && addStep.phase === 'selectType' && (
+                        <div className="flex gap-1">
+                          <button
+                            type="button"
+                            onClick={() => handleSelectType('ate')}
+                            className="flex-1 px-2 py-1 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 cursor-pointer"
+                          >
+                            食べた
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleSelectType('cooked')}
+                            className="flex-1 px-2 py-1 text-xs font-medium bg-green-600 text-white rounded-lg hover:bg-green-700 cursor-pointer"
+                          >
+                            作った
+                          </button>
+                        </div>
+                      )}
+
+                      {isSelected && addStep.phase === 'selectMealTime' && (
+                        <div className="flex gap-1">
+                          {MEAL_TIME_VALUES.map(({ key, label }) => (
+                            <button
+                              key={key}
+                              type="button"
+                              onClick={() => handleSelectMealTime(key)}
+                              className="flex-1 px-2 py-1 text-xs font-medium bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 cursor-pointer"
+                            >
+                              {label}
+                            </button>
+                          ))}
+                        </div>
+                      )}
                     </div>
-                  ) : (
-                    <div className="aspect-square w-full bg-zinc-100 flex items-center justify-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-zinc-300"><path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"/><path d="M7 2v20"/><path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"/></svg>
-                    </div>
-                  )}
-                  <div className="flex items-center justify-between gap-2 p-3">
-                    <p className="text-sm text-zinc-700 leading-snug line-clamp-2 flex-1">{recipe.title}</p>
-                    <button
-                      type="button"
-                      aria-label="追加"
-                      disabled={isPending}
-                      onClick={() => handleAdd(recipe.id)}
-                      className="flex-shrink-0 px-2 py-1 text-xs font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 disabled:opacity-50 cursor-pointer"
-                    >
-                      追加
-                    </button>
                   </div>
-                </div>
-              </li>
-            ))}
+                </li>
+              )
+            })}
           </ul>
         )}
       </section>

--- a/app/components/HomeTabs.test.tsx
+++ b/app/components/HomeTabs.test.tsx
@@ -2,43 +2,86 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-vi.mock('./CalendarView', () => ({ default: () => <div>CalendarView</div> }))
+vi.mock('./WeekView', () => ({ default: () => <div>WeekView</div> }))
 vi.mock('./RecipeList', () => ({ default: () => <div>RecipeList</div> }))
 vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }))
+vi.mock('../(auth)/actions', () => ({ signOut: vi.fn() }))
+vi.mock('./AddRecipeDropdown', () => ({ default: () => <div>AddRecipeDropdown</div> }))
 
 import HomeTabs from './HomeTabs'
+
+const defaultUser = { email: 'test@example.com' }
+const defaultProps = { recipes: [], mealRecords: [], user: defaultUser, recipeCount: 0 }
 
 describe('HomeTabs', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('リストタブとカレンダータブが表示される', () => {
-    render(<HomeTabs recipes={[]} mealRecords={[]} />)
+  it('リスト・カレンダー・アカウントタブが表示される', () => {
+    render(<HomeTabs {...defaultProps} />)
     expect(screen.getByRole('button', { name: 'リスト' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'カレンダー' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'アカウント' })).toBeInTheDocument()
   })
 
   it('デフォルトでリストタブが選択されRecipeListが表示される', () => {
-    render(<HomeTabs recipes={[]} mealRecords={[]} />)
+    render(<HomeTabs {...defaultProps} />)
     expect(screen.getByText('RecipeList')).toBeInTheDocument()
-    expect(screen.queryByText('CalendarView')).not.toBeInTheDocument()
+    expect(screen.queryByText('WeekView')).not.toBeInTheDocument()
   })
 
-  it('カレンダータブクリックでCalendarViewが表示される', async () => {
+  it('カレンダータブクリックでWeekViewが表示される', async () => {
     const user = userEvent.setup()
-    render(<HomeTabs recipes={[]} mealRecords={[]} />)
+    render(<HomeTabs {...defaultProps} />)
     await user.click(screen.getByRole('button', { name: 'カレンダー' }))
-    expect(screen.getByText('CalendarView')).toBeInTheDocument()
+    expect(screen.getByText('WeekView')).toBeInTheDocument()
     expect(screen.queryByText('RecipeList')).not.toBeInTheDocument()
   })
 
   it('カレンダーからリストタブに戻れる', async () => {
     const user = userEvent.setup()
-    render(<HomeTabs recipes={[]} mealRecords={[]} />)
+    render(<HomeTabs {...defaultProps} />)
     await user.click(screen.getByRole('button', { name: 'カレンダー' }))
     await user.click(screen.getByRole('button', { name: 'リスト' }))
     expect(screen.getByText('RecipeList')).toBeInTheDocument()
-    expect(screen.queryByText('CalendarView')).not.toBeInTheDocument()
+    expect(screen.queryByText('WeekView')).not.toBeInTheDocument()
+  })
+
+  it('ヘッダーはどのタブでも表示されない', () => {
+    render(<HomeTabs {...defaultProps} user={{ email: 'hello@example.com' }} />)
+    expect(screen.queryByRole('banner')).not.toBeInTheDocument()
+  })
+
+  it('アカウントタブでメールアドレスが表示される', async () => {
+    const user = userEvent.setup()
+    render(<HomeTabs {...defaultProps} user={{ email: 'hello@example.com' }} />)
+    await user.click(screen.getByRole('button', { name: 'アカウント' }))
+    expect(screen.getByText('hello@example.com')).toBeInTheDocument()
+  })
+
+  it('アカウントタブでログアウトボタンが表示される', async () => {
+    const user = userEvent.setup()
+    render(<HomeTabs {...defaultProps} />)
+    await user.click(screen.getByRole('button', { name: 'アカウント' }))
+    expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument()
+  })
+
+  it('リストタブではレシピ件数が表示される', () => {
+    render(<HomeTabs {...defaultProps} recipeCount={5} />)
+    expect(screen.getByText('5件のレシピ')).toBeInTheDocument()
+  })
+
+  it('カレンダータブではレシピ件数が非表示になる', async () => {
+    const user = userEvent.setup()
+    render(<HomeTabs {...defaultProps} recipeCount={5} />)
+    await user.click(screen.getByRole('button', { name: 'カレンダー' }))
+    expect(screen.queryByText('5件のレシピ')).not.toBeInTheDocument()
+  })
+
+  it('ボトムタブバーが常に表示される', () => {
+    render(<HomeTabs {...defaultProps} />)
+    const nav = screen.getByRole('navigation')
+    expect(nav).toBeInTheDocument()
   })
 })

--- a/app/components/HomeTabs.tsx
+++ b/app/components/HomeTabs.tsx
@@ -3,7 +3,9 @@
 import { useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import RecipeList from './RecipeList'
-import CalendarView from './CalendarView'
+import WeekView from './WeekView'
+import { signOut } from '../(auth)/actions'
+import AddRecipeDropdown from './AddRecipeDropdown'
 
 type Recipe = {
   id: string
@@ -19,54 +21,89 @@ type MealRecord = {
   id: string
   recipeId: string
   date: Date
+  type: string
+  mealTime: string | null
   recipe: { id: string; title: string }
 }
 
 type HomeTabsProps = {
   recipes: Recipe[]
   mealRecords: MealRecord[]
+  user: { email: string | undefined }
+  recipeCount: number
 }
 
-type Tab = 'list' | 'calendar'
+type Tab = 'list' | 'calendar' | 'account'
 
-export default function HomeTabs({ recipes, mealRecords }: HomeTabsProps) {
+export default function HomeTabs({ recipes, mealRecords, user, recipeCount }: HomeTabsProps) {
   const searchParams = useSearchParams()
   const [activeTab, setActiveTab] = useState<Tab>(
     searchParams.get('tab') === 'calendar' ? 'calendar' : 'list'
   )
 
   return (
-    <div className={`flex flex-col ${activeTab === 'calendar' ? 'flex-1 min-h-0' : ''}`}>
-      <div className="flex gap-2 mb-6">
-        <button
-          type="button"
-          onClick={() => setActiveTab('list')}
-          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors cursor-pointer ${
-            activeTab === 'list'
-              ? 'bg-zinc-900 text-white'
-              : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'
-          }`}
-        >
-          リスト
-        </button>
-        <button
-          type="button"
-          onClick={() => setActiveTab('calendar')}
-          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors cursor-pointer ${
-            activeTab === 'calendar'
-              ? 'bg-zinc-900 text-white'
-              : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'
-          }`}
-        >
-          カレンダー
-        </button>
-      </div>
+    <div className="min-h-screen flex flex-col bg-zinc-50">
+      <main className={activeTab === 'list'
+        ? 'max-w-7xl w-full mx-auto px-4 py-8 flex-1 flex flex-col pb-20'
+        : 'flex-1 flex flex-col px-2 pt-4 pb-20 min-h-0'
+      }>
+        {activeTab === 'list' && (
+          <>
+            <div className="flex items-center justify-between mb-6">
+              <p className="text-sm text-zinc-500">{recipeCount}件のレシピ</p>
+              <AddRecipeDropdown />
+            </div>
+            <RecipeList recipes={recipes} />
+          </>
+        )}
 
-      {activeTab === 'list' ? (
-        <RecipeList recipes={recipes} />
-      ) : (
-        <div className="flex flex-col flex-1 min-h-0 overflow-hidden"><CalendarView mealRecords={mealRecords} recipes={recipes} /></div>
-      )}
+        {activeTab === 'calendar' && (
+          <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+            <WeekView mealRecords={mealRecords} recipes={recipes} />
+          </div>
+        )}
+
+        {activeTab === 'account' && (
+          <div className="max-w-7xl w-full mx-auto px-4 py-8 flex flex-col gap-6">
+            <h2 className="text-lg font-semibold text-zinc-900">アカウント</h2>
+            <div className="bg-white rounded-xl border border-zinc-200 divide-y divide-zinc-100">
+              <div className="px-4 py-3">
+                <p className="text-xs text-zinc-400 mb-0.5">メールアドレス</p>
+                <p className="text-sm text-zinc-700">{user.email}</p>
+              </div>
+              <div className="px-4 py-3">
+                <form action={signOut}>
+                  <button
+                    type="submit"
+                    className="text-sm font-medium text-red-600 hover:text-red-800 transition-colors cursor-pointer"
+                  >
+                    ログアウト
+                  </button>
+                </form>
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+
+      <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-zinc-200 z-50 flex justify-center py-3" style={{ paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))' }}>
+        <div className="flex gap-2">
+          {([
+            { key: 'list', label: 'リスト' },
+            { key: 'calendar', label: 'カレンダー' },
+            { key: 'account', label: 'アカウント' },
+          ] as { key: Tab; label: string }[]).map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setActiveTab(key)}
+              className={`px-5 py-2 rounded-full text-sm font-medium transition-colors cursor-pointer ${activeTab === key ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </nav>
     </div>
   )
 }

--- a/app/components/WeekView.test.tsx
+++ b/app/components/WeekView.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const { mockRouterPush } = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+import WeekView from './WeekView'
+
+// 固定の基準日: 2026-03-09(月) 〜 2026-03-15(日) の週
+const MONDAY = new Date('2026-03-09T00:00:00')
+
+const makeMealRecord = (
+  id: string,
+  recipeId: string,
+  title: string,
+  date: string,
+  type: string,
+  mealTime: string | null,
+) => ({
+  id,
+  recipeId,
+  date: new Date(date + 'T00:00:00'),
+  type,
+  mealTime,
+  recipe: { id: recipeId, title },
+})
+
+const defaultProps = {
+  mealRecords: [] as ReturnType<typeof makeMealRecord>[],
+  recipes: [],
+  initialDate: MONDAY,
+}
+
+describe('WeekView', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('前週・翌週ボタンが表示される', () => {
+    render(<WeekView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: '前週' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '翌週' })).toBeInTheDocument()
+  })
+
+  it('initialDate を含む週の7日分が表示される', () => {
+    render(<WeekView {...defaultProps} />)
+    // 2026-03-09(月)〜2026-03-15(日)
+    expect(screen.getByText('3/9')).toBeInTheDocument()
+    expect(screen.getByText('3/15')).toBeInTheDocument()
+  })
+
+  it('週の範囲ラベルが表示される', () => {
+    render(<WeekView {...defaultProps} />)
+    expect(screen.getByText(/3月9日.*3月15日/)).toBeInTheDocument()
+  })
+
+  it('フィルターボタン「すべて / 食べた / 作った」が表示される', () => {
+    render(<WeekView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'すべて' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '食べた' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '作った' })).toBeInTheDocument()
+  })
+
+  it('type=ate, mealTime=lunch の記録が「昼」ラベルで表示される', () => {
+    const records = [makeMealRecord('m1', 'r1', 'カレー', '2026-03-09', 'ate', 'lunch')]
+    render(<WeekView {...defaultProps} mealRecords={records} />)
+    expect(screen.getByText('昼')).toBeInTheDocument()
+    expect(screen.getByText('カレー')).toBeInTheDocument()
+  })
+
+  it('type=ate, mealTime=breakfast の記録が「朝」ラベルで表示される', () => {
+    const records = [makeMealRecord('m1', 'r1', 'トースト', '2026-03-09', 'ate', 'breakfast')]
+    render(<WeekView {...defaultProps} mealRecords={records} />)
+    expect(screen.getByText('朝')).toBeInTheDocument()
+    expect(screen.getByText('トースト')).toBeInTheDocument()
+  })
+
+  it('type=ate, mealTime=dinner の記録が「夜」ラベルで表示される', () => {
+    const records = [makeMealRecord('m1', 'r1', '肉じゃが', '2026-03-09', 'ate', 'dinner')]
+    render(<WeekView {...defaultProps} mealRecords={records} />)
+    expect(screen.getByText('夜')).toBeInTheDocument()
+    expect(screen.getByText('肉じゃが')).toBeInTheDocument()
+  })
+
+  it('type=cooked の記録が「作」バッジで表示される', () => {
+    const records = [makeMealRecord('m1', 'r1', '唐揚げ', '2026-03-09', 'cooked', null)]
+    render(<WeekView {...defaultProps} mealRecords={records} />)
+    expect(screen.getByText('作')).toBeInTheDocument()
+    expect(screen.getByText('唐揚げ')).toBeInTheDocument()
+  })
+
+  it('フィルター「食べた」で cooked 記録が非表示になる', async () => {
+    const user = userEvent.setup()
+    const records = [
+      makeMealRecord('m1', 'r1', 'カレー', '2026-03-09', 'ate', 'lunch'),
+      makeMealRecord('m2', 'r2', '唐揚げ', '2026-03-09', 'cooked', null),
+    ]
+    render(<WeekView {...defaultProps} mealRecords={records} />)
+    await user.click(screen.getByRole('button', { name: '食べた' }))
+    expect(screen.getByText('カレー')).toBeInTheDocument()
+    expect(screen.queryByText('唐揚げ')).not.toBeInTheDocument()
+  })
+
+  it('フィルター「作った」で ate 記録が非表示になる', async () => {
+    const user = userEvent.setup()
+    const records = [
+      makeMealRecord('m1', 'r1', 'カレー', '2026-03-09', 'ate', 'lunch'),
+      makeMealRecord('m2', 'r2', '唐揚げ', '2026-03-09', 'cooked', null),
+    ]
+    render(<WeekView {...defaultProps} mealRecords={records} />)
+    await user.click(screen.getByRole('button', { name: '作った' }))
+    expect(screen.queryByText('カレー')).not.toBeInTheDocument()
+    expect(screen.getByText('唐揚げ')).toBeInTheDocument()
+  })
+
+  it('フィルター「すべて」で全記録が表示される', async () => {
+    const user = userEvent.setup()
+    const records = [
+      makeMealRecord('m1', 'r1', 'カレー', '2026-03-09', 'ate', 'lunch'),
+      makeMealRecord('m2', 'r2', '唐揚げ', '2026-03-09', 'cooked', null),
+    ]
+    render(<WeekView {...defaultProps} mealRecords={records} />)
+    await user.click(screen.getByRole('button', { name: '作った' }))
+    await user.click(screen.getByRole('button', { name: 'すべて' }))
+    expect(screen.getByText('カレー')).toBeInTheDocument()
+    expect(screen.getByText('唐揚げ')).toBeInTheDocument()
+  })
+
+  it('前週ボタンで週が切り替わる', async () => {
+    const user = userEvent.setup()
+    render(<WeekView {...defaultProps} />)
+    await user.click(screen.getByRole('button', { name: '前週' }))
+    expect(screen.getByText('3/2')).toBeInTheDocument()
+    expect(screen.getByText('3/8')).toBeInTheDocument()
+  })
+
+  it('翌週ボタンで週が切り替わる', async () => {
+    const user = userEvent.setup()
+    render(<WeekView {...defaultProps} />)
+    await user.click(screen.getByRole('button', { name: '翌週' }))
+    expect(screen.getByText('3/16')).toBeInTheDocument()
+    expect(screen.getByText('3/22')).toBeInTheDocument()
+  })
+
+  it('日付クリックで /calendar/YYYY-MM-DD へ遷移する', async () => {
+    const user = userEvent.setup()
+    render(<WeekView {...defaultProps} />)
+    await user.click(screen.getByTestId('day-row-2026-03-09'))
+    expect(mockRouterPush).toHaveBeenCalledWith('/calendar/2026-03-09')
+  })
+})

--- a/app/components/WeekView.tsx
+++ b/app/components/WeekView.tsx
@@ -1,0 +1,233 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+
+type Recipe = {
+  id: string
+  title: string
+}
+
+type MealRecord = {
+  id: string
+  recipeId: string
+  date: Date
+  type: string
+  mealTime: string | null
+  recipe: { id: string; title: string }
+}
+
+type WeekViewProps = {
+  mealRecords: MealRecord[]
+  recipes: Recipe[]
+  initialDate?: Date
+}
+
+type Filter = 'all' | 'ate' | 'cooked'
+
+const MEAL_TIME_LABELS: Record<string, string> = {
+  breakfast: '朝',
+  lunch: '昼',
+  dinner: '夜',
+}
+
+const MEAL_TIME_ORDER = ['breakfast', 'lunch', 'dinner']
+
+function toDateKey(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function getWeekMonday(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay()
+  // 月曜始まり (0=日 → -6, 1=月 → 0, ..., 6=土 → -5)
+  const diff = day === 0 ? -6 : 1 - day
+  d.setDate(d.getDate() + diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function buildWeekDays(monday: Date): Date[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(monday)
+    d.setDate(monday.getDate() + i)
+    return d
+  })
+}
+
+const DAY_LABELS = ['月', '火', '水', '木', '金', '土', '日']
+
+export default function WeekView({ mealRecords, initialDate }: WeekViewProps) {
+  const router = useRouter()
+  const [weekMonday, setWeekMonday] = useState(() => getWeekMonday(initialDate ?? new Date()))
+  const [filter, setFilter] = useState<Filter>('all')
+
+  const days = useMemo(() => buildWeekDays(weekMonday), [weekMonday])
+
+  const recordsByDate = useMemo(() => {
+    const map: Record<string, MealRecord[]> = {}
+    for (const record of mealRecords) {
+      const key = toDateKey(new Date(record.date))
+      if (!map[key]) map[key] = []
+      map[key].push(record)
+    }
+    return map
+  }, [mealRecords])
+
+  const goToPrevWeek = () => {
+    const d = new Date(weekMonday)
+    d.setDate(d.getDate() - 7)
+    setWeekMonday(d)
+  }
+
+  const goToNextWeek = () => {
+    const d = new Date(weekMonday)
+    d.setDate(d.getDate() + 7)
+    setWeekMonday(d)
+  }
+
+  const weekEnd = days[6]
+  const rangeLabel = `${weekMonday.getMonth() + 1}月${weekMonday.getDate()}日〜${weekEnd.getMonth() + 1}月${weekEnd.getDate()}日`
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      {/* 週ナビゲーション */}
+      <div className="flex items-center justify-between mb-3">
+        <button
+          type="button"
+          aria-label="前週"
+          onClick={goToPrevWeek}
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 transition-colors cursor-pointer"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+          前週
+        </button>
+        <span className="text-sm font-semibold text-zinc-900">{rangeLabel}</span>
+        <button
+          type="button"
+          aria-label="翌週"
+          onClick={goToNextWeek}
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 transition-colors cursor-pointer"
+        >
+          翌週
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+      </div>
+
+      {/* フィルター */}
+      <div className="flex gap-2 mb-4">
+        {(['all', 'ate', 'cooked'] as Filter[]).map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => setFilter(f)}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition-colors cursor-pointer ${
+              filter === f ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'
+            }`}
+          >
+            {f === 'all' ? 'すべて' : f === 'ate' ? '食べた' : '作った'}
+          </button>
+        ))}
+      </div>
+
+      {/* 日付リスト */}
+      <div className="flex flex-col gap-2 flex-1 overflow-y-auto">
+        {days.map((day, i) => {
+          const dateKey = toDateKey(day)
+          const allRecords = recordsByDate[dateKey] ?? []
+          const ateRecords = allRecords.filter((r) => r.type === 'ate')
+          const cookedRecords = allRecords.filter((r) => r.type === 'cooked')
+
+          const showAte = filter !== 'cooked'
+          const showCooked = filter !== 'ate'
+
+          const isToday = toDateKey(new Date()) === dateKey
+          const isSunday = i === 6
+          const isSaturday = i === 5
+
+          return (
+            <button
+              key={dateKey}
+              type="button"
+              data-testid={`day-row-${dateKey}`}
+              onClick={() => router.push(`/calendar/${dateKey}`)}
+              className={`w-full text-left rounded-xl border px-3 py-2 transition-colors cursor-pointer hover:bg-zinc-50 ${
+                isToday ? 'border-zinc-400 bg-zinc-50' : 'border-zinc-200 bg-white'
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                {/* 日付 */}
+                <div className="flex-shrink-0 w-10 pt-0.5">
+                  <span className={`text-xs font-medium ${isSunday ? 'text-red-500' : isSaturday ? 'text-blue-500' : 'text-zinc-500'}`}>
+                    {DAY_LABELS[i]}
+                  </span>
+                  <p className={`text-sm font-semibold leading-tight ${isToday ? 'text-zinc-900' : 'text-zinc-700'}`}>
+                    {day.getMonth() + 1}/{day.getDate()}
+                  </p>
+                </div>
+
+                {/* 記録 */}
+                <div className="flex-1 flex flex-col gap-1 min-w-0">
+                  {/* 食べた: 時間帯グルーピング */}
+                  {showAte && MEAL_TIME_ORDER.map((mt) => {
+                    const recs = ateRecords.filter((r) => r.mealTime === mt)
+                    if (recs.length === 0) return null
+                    return (
+                      <div key={mt} className="flex items-start gap-1.5">
+                        <span className="flex-shrink-0 text-xs text-zinc-400 w-4 pt-0.5">{MEAL_TIME_LABELS[mt]}</span>
+                        <div className="flex flex-wrap gap-1 min-w-0">
+                          {recs.map((r) => (
+                            <span key={r.id} className="text-xs bg-blue-50 text-blue-700 rounded px-1.5 py-0.5 truncate max-w-full">
+                              {r.recipe.title}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )
+                  })}
+
+                  {/* 食べたが mealTime=null のもの */}
+                  {showAte && (() => {
+                    const recs = ateRecords.filter((r) => r.mealTime === null)
+                    if (recs.length === 0) return null
+                    return (
+                      <div className="flex flex-wrap gap-1">
+                        {recs.map((r) => (
+                          <span key={r.id} className="text-xs bg-blue-50 text-blue-700 rounded px-1.5 py-0.5 truncate max-w-full">
+                            {r.recipe.title}
+                          </span>
+                        ))}
+                      </div>
+                    )
+                  })()}
+
+                  {/* 作った */}
+                  {showCooked && cookedRecords.length > 0 && (
+                    <div className="flex items-start gap-1.5">
+                      <span className="flex-shrink-0 text-xs text-zinc-400 w-4 pt-0.5">作</span>
+                      <div className="flex flex-wrap gap-1 min-w-0">
+                        {cookedRecords.map((r) => (
+                          <span key={r.id} className="text-xs bg-green-50 text-green-700 rounded px-1.5 py-0.5 truncate max-w-full">
+                            {r.recipe.title}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* 記録なし */}
+                  {allRecords.length === 0 && (
+                    <span className="text-xs text-zinc-300">記録なし</span>
+                  )}
+                </div>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/meal-records/actions.test.ts
+++ b/app/meal-records/actions.test.ts
@@ -60,7 +60,7 @@ describe('createMealRecord', () => {
     expect(mockMealRecordCreate).not.toHaveBeenCalled()
   })
 
-  it('成功時: create を正しい引数で呼ぶ', async () => {
+  it('成功時: type/mealTime 未指定はデフォルト値で create を呼ぶ', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
     mockMealRecordCreate.mockResolvedValue({ id: 'meal-1' })
@@ -72,6 +72,44 @@ describe('createMealRecord', () => {
         userId: 'user-1',
         recipeId: 'recipe-1',
         date: new Date('2026-03-01'),
+        type: 'ate',
+        mealTime: null,
+      },
+    })
+  })
+
+  it('type=ate, mealTime=lunch で create を呼ぶ', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockMealRecordCreate.mockResolvedValue({ id: 'meal-1' })
+
+    await createMealRecord({ recipeId: 'recipe-1', date: '2026-03-01', type: 'ate', mealTime: 'lunch' })
+
+    expect(mockMealRecordCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        recipeId: 'recipe-1',
+        date: new Date('2026-03-01'),
+        type: 'ate',
+        mealTime: 'lunch',
+      },
+    })
+  })
+
+  it('type=cooked で create を呼ぶ', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockMealRecordCreate.mockResolvedValue({ id: 'meal-1' })
+
+    await createMealRecord({ recipeId: 'recipe-1', date: '2026-03-01', type: 'cooked' })
+
+    expect(mockMealRecordCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        recipeId: 'recipe-1',
+        date: new Date('2026-03-01'),
+        type: 'cooked',
+        mealTime: null,
       },
     })
   })

--- a/app/meal-records/actions.ts
+++ b/app/meal-records/actions.ts
@@ -4,7 +4,7 @@ import { createClient } from '../utils/supabase/server'
 import { prisma } from '../../lib/prisma'
 import { redirect } from 'next/navigation'
 
-export async function createMealRecord(input: { recipeId: string; date: string }): Promise<void> {
+export async function createMealRecord(input: { recipeId: string; date: string; type?: string; mealTime?: string | null }): Promise<void> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 
@@ -24,6 +24,8 @@ export async function createMealRecord(input: { recipeId: string; date: string }
       userId: user.id,
       recipeId: input.recipeId,
       date: new Date(input.date),
+      type: input.type ?? 'ate',
+      mealTime: input.mealTime ?? null,
     },
   })
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,6 @@
 import { Suspense } from 'react'
-import { signOut } from './(auth)/actions'
 import { createClient } from './utils/supabase/server'
 import { prisma } from '../lib/prisma'
-import AddRecipeDropdown from './components/AddRecipeDropdown'
 import HomeTabs from './components/HomeTabs'
 
 export default async function Home() {
@@ -31,34 +29,13 @@ export default async function Home() {
   ])
 
   return (
-    <div className="min-h-screen flex flex-col bg-zinc-50">
-      <header className="bg-white border-b border-zinc-200">
-        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-          <h1 className="text-lg font-semibold text-zinc-900">ぽけっと レシピ</h1>
-          <div className="flex items-center gap-4">
-            <span className="text-sm text-zinc-500">{user?.email}</span>
-            <form action={signOut}>
-              <button
-                type="submit"
-                className="text-sm font-medium text-zinc-700 hover:text-zinc-900 transition-colors"
-              >
-                ログアウト
-              </button>
-            </form>
-          </div>
-        </div>
-      </header>
-
-      <main className="max-w-7xl w-full mx-auto px-4 py-8 flex-1 flex flex-col">
-        <div className="flex items-center justify-between mb-6">
-          <p className="text-sm text-zinc-500">{recipes.length}件のレシピ</p>
-          <AddRecipeDropdown />
-        </div>
-
-        <Suspense>
-          <HomeTabs recipes={recipes} mealRecords={mealRecords} />
-        </Suspense>
-      </main>
-    </div>
+    <Suspense>
+      <HomeTabs
+        recipes={recipes}
+        mealRecords={mealRecords}
+        user={{ email: user?.email }}
+        recipeCount={recipes.length}
+      />
+    </Suspense>
   )
 }

--- a/prisma/migrations/20260313133827_add_type_mealtime_to_meal_records/migration.sql
+++ b/prisma/migrations/20260313133827_add_type_mealtime_to_meal_records/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "meal_records" ADD COLUMN     "meal_time" TEXT,
+ADD COLUMN     "type" TEXT NOT NULL DEFAULT 'ate';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,8 @@ model MealRecord {
   userId    String   @map("user_id")
   recipeId  String   @map("recipe_id")
   date      DateTime @map("date") @db.Date
+  type      String   @default("ate") // 'ate' | 'cooked'
+  mealTime  String?  @map("meal_time") // 'breakfast' | 'lunch' | 'dinner' | null
   createdAt DateTime @default(now()) @map("created_at")
 
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
レスポンシブデザインの改善のつもりだったが、カレンダーが思った以上にレシピと親和性が悪かったので、週ごとに表示するように変更した

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #46 

## やったこと
<!-- このPRで何をしたのか -->
- MealRecord に type（食べた/作った）と mealTime（朝/昼/夜）カラムを追加し、DBマイグレーション実施
- createMealRecord Server Action に type / mealTime 引数を追加
- 月カレンダー（CalendarView）を週表示（WeekView）に置き換え
  - 前週/翌週ナビゲーション
  - 朝/昼/夜グルーピング表示、「作った」は緑バッジで区別
  - すべて/食べた/作った フィルター
  - 今日をハイライト
- /calendar/[date] の登録UIを2ステップに変更（追加→食べた/作った選択→朝/昼/夜選択）
- 登録済みレコードに「食べた / 昼」「作った」などラベル表示
- ヘッダーを全タブから削除
- ボトムナビに「アカウント」タブを追加し、メールアドレス表示とログアウトをそこに移動
- レスポンシブUI改善（カレンダータブはフルWidth、ヘッダーなし）

## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
