### PR TITLE
【feature/41】画像変換処理の改善

### DIFF
--- a/app/recipes/new/from-photo/page.test.tsx
+++ b/app/recipes/new/from-photo/page.test.tsx
@@ -3,11 +3,11 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ParsedRecipe } from '../../../types/recipe'
 
-const { mockParseRecipe, mockCreateRecipe, mockRouterBack, mockConvertImage } = vi.hoisted(() => ({
+const { mockParseRecipe, mockCreateRecipe, mockRouterBack, mockPrepareImageForCrop } = vi.hoisted(() => ({
   mockParseRecipe: vi.fn(),
   mockCreateRecipe: vi.fn(),
   mockRouterBack: vi.fn(),
-  mockConvertImage: vi.fn(),
+  mockPrepareImageForCrop: vi.fn(),
 }))
 
 vi.mock('../../../utils/recipeParser', () => ({
@@ -23,7 +23,7 @@ vi.mock('next/navigation', () => ({
 }))
 
 vi.mock('../../../utils/imageConverter', () => ({
-  convertImage: mockConvertImage,
+  prepareImageForCrop: mockPrepareImageForCrop,
 }))
 
 vi.mock('../../../utils/supabase/client', () => ({
@@ -38,6 +38,33 @@ vi.mock('../../../utils/supabase/client', () => ({
   }),
 }))
 
+// Mock react-image-crop to render a simple img wrapper
+vi.mock('react-image-crop', async () => {
+  const React = await import('react')
+  return {
+    default: ({ children }: { children: React.ReactNode }) => React.createElement('div', { 'data-testid': 'react-crop' }, children),
+    centerCrop: vi.fn((c) => c),
+    makeAspectCrop: vi.fn(() => ({ unit: '%', width: 90, x: 0, y: 0, height: 90 })),
+  }
+})
+
+// Mock canvas toBlob and getContext
+Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+  value: function (cb: (b: Blob | null) => void) {
+    cb(new Blob(['img'], { type: 'image/jpeg' }))
+  },
+})
+
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  value: () => ({
+    drawImage: vi.fn(),
+  }),
+})
+
+// Mock HTMLImageElement natural dimensions
+Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', { get: () => 100 })
+Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', { get: () => 100 })
+
 import FromPhotoPage from './page'
 
 const validRecipe: ParsedRecipe = {
@@ -49,22 +76,26 @@ const validRecipe: ParsedRecipe = {
   steps: ['玉ねぎを炒める', 'カレールーを加える'],
 }
 
+// Helper: upload a file and confirm the crop
+async function uploadAndConfirmCrop(user: ReturnType<typeof userEvent.setup>, file: File) {
+  await user.upload(screen.getByLabelText('写真を選択'), file)
+  await waitFor(() => expect(screen.getByText('この範囲で決定')).toBeInTheDocument())
+  await user.click(screen.getByText('この範囲で決定'))
+}
+
 describe('FromPhotoPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockConvertImage.mockImplementation((file: File) =>
-      Promise.resolve({ convertedFile: file, previewUrl: 'blob:mock' })
-    )
+    mockPrepareImageForCrop.mockResolvedValue('blob:mock')
     mockParseRecipe.mockResolvedValue(validRecipe)
   })
 
   it('初期表示では写真アップロードエリアのみ表示', () => {
     render(<FromPhotoPage />)
-
     expect(screen.getByText('タップして写真を選択')).toBeInTheDocument()
   })
 
-  it('画像選択後にプレビューが表示される', async () => {
+  it('画像選択後にクロップUIが表示される', async () => {
     const user = userEvent.setup()
     render(<FromPhotoPage />)
 
@@ -72,16 +103,28 @@ describe('FromPhotoPage', () => {
     await user.upload(screen.getByLabelText('写真を選択'), file)
 
     await waitFor(() => {
-      expect(screen.getByRole('img', { name: 'プレビュー' })).toBeInTheDocument()
+      expect(screen.getByText('この範囲で決定')).toBeInTheDocument()
     })
   })
 
-  it('画像選択後に自動で parseRecipeFromImage が呼ばれ、フォームに自動入力される', async () => {
+  it('クロップ確定後にプレビューが表示される', async () => {
     const user = userEvent.setup()
     render(<FromPhotoPage />)
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
-    await user.upload(screen.getByLabelText('写真を選択'), file)
+    await uploadAndConfirmCrop(user, file)
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: 'プレビュー' })).toBeInTheDocument()
+    })
+  })
+
+  it('クロップ確定後に自動で parseRecipeFromImage が呼ばれ、フォームに自動入力される', async () => {
+    const user = userEvent.setup()
+    render(<FromPhotoPage />)
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await uploadAndConfirmCrop(user, file)
 
     await waitFor(() => {
       expect(mockParseRecipe).toHaveBeenCalled()
@@ -92,14 +135,14 @@ describe('FromPhotoPage', () => {
     })
   })
 
-  it('解析中は "AI解析中..." が表示される', async () => {
+  it('解析中は "画像読み取り中・・・" が表示される', async () => {
     const user = userEvent.setup()
     let resolvePromise!: (v: ParsedRecipe) => void
     mockParseRecipe.mockReturnValue(new Promise<ParsedRecipe>((resolve) => { resolvePromise = resolve }))
     render(<FromPhotoPage />)
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
-    await user.upload(screen.getByLabelText('写真を選択'), file)
+    await uploadAndConfirmCrop(user, file)
 
     await waitFor(() => {
       expect(screen.getByText('画像読み取り中・・・')).toBeInTheDocument()
@@ -114,7 +157,7 @@ describe('FromPhotoPage', () => {
     render(<FromPhotoPage />)
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
-    await user.upload(screen.getByLabelText('写真を選択'), file)
+    await uploadAndConfirmCrop(user, file)
 
     await waitFor(() => {
       expect(screen.getByText(/解析に失敗しました/)).toBeInTheDocument()
@@ -137,7 +180,7 @@ describe('FromPhotoPage', () => {
     await user.type(screen.getByPlaceholderText('例: 肉じゃが'), '手動タイトル')
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
-    await user.upload(screen.getByLabelText('写真を選択'), file)
+    await uploadAndConfirmCrop(user, file)
 
     await waitFor(() => expect(mockParseRecipe).toHaveBeenCalled())
     expect(screen.getByDisplayValue('手動タイトル')).toBeInTheDocument()
@@ -148,7 +191,7 @@ describe('FromPhotoPage', () => {
     render(<FromPhotoPage />)
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
-    await user.upload(screen.getByLabelText('写真を選択'), file)
+    await uploadAndConfirmCrop(user, file)
 
     await waitFor(() => screen.getByDisplayValue('カレーライス'))
     const titleInput = screen.getByDisplayValue('カレーライス')

--- a/app/recipes/new/from-photo/page.tsx
+++ b/app/recipes/new/from-photo/page.tsx
@@ -1,12 +1,58 @@
 'use client'
 
-import { useState, useTransition } from 'react'
+import { useState, useTransition, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
+import ReactCrop, { type Crop, centerCrop, makeAspectCrop } from 'react-image-crop'
+import 'react-image-crop/dist/ReactCrop.css'
 import { createRecipe, type IngredientInput, type StepInput } from '../../actions'
 import { createClient } from '../../../utils/supabase/client'
-import { convertImage } from '../../../utils/imageConverter'
+import { prepareImageForCrop } from '../../../utils/imageConverter'
 import { parseRecipeFromImage } from '../../../utils/recipeParser'
+
+async function cropAndConvert(
+  imgElement: HTMLImageElement,
+  crop: Crop,
+  maxSize = 1024
+): Promise<File> {
+  const naturalW = imgElement.naturalWidth || imgElement.width || 100
+  const naturalH = imgElement.naturalHeight || imgElement.height || 100
+  const displayW = imgElement.width || naturalW
+  const displayH = imgElement.height || naturalH
+  const scaleX = naturalW / displayW
+  const scaleY = naturalH / displayH
+
+  const isPercent = crop.unit === '%'
+  const cropX = isPercent ? (crop.x / 100) * naturalW : crop.x * scaleX
+  const cropY = isPercent ? (crop.y / 100) * naturalH : crop.y * scaleY
+  const cropWidth = isPercent ? (crop.width / 100) * naturalW : crop.width * scaleX
+  const cropHeight = isPercent ? (crop.height / 100) * naturalH : crop.height * scaleY
+
+  const outputWidth = Math.min(cropWidth || naturalW, maxSize)
+  const outputHeight = cropWidth
+    ? Math.min(cropHeight, maxSize * (cropHeight / cropWidth))
+    : Math.min(naturalH, maxSize)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = outputWidth
+  canvas.height = outputHeight
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas context unavailable')
+
+  ctx.drawImage(imgElement, cropX, cropY, cropWidth, cropHeight, 0, 0, outputWidth, outputHeight)
+
+  return new Promise<File>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) { reject(new Error('Canvas toBlob failed')); return }
+        resolve(new File([blob], 'recipe.jpg', { type: 'image/jpeg' }))
+      },
+      'image/jpeg',
+      0.7
+    )
+  })
+}
 
 export default function FromPhotoPage() {
   const router = useRouter()
@@ -29,6 +75,11 @@ export default function FromPhotoPage() {
   const [isParsing, setIsParsing] = useState(false)
   const [parseError, setParseError] = useState<string | null>(null)
 
+  const [cropSrc, setCropSrc] = useState<string | null>(null)
+  const [crop, setCrop] = useState<Crop>()
+  const [isConverting, setIsConverting] = useState(false)
+  const imgRef = useRef<HTMLImageElement>(null)
+
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
@@ -38,19 +89,40 @@ export default function FromPhotoPage() {
     }
     setUploadError(null)
     setParseError(null)
-    let convertedFile: File
+    setIsConverting(true)
     try {
-      const result = await convertImage(file)
-      convertedFile = result.convertedFile
-      setImageFile(convertedFile)
-      setImagePreviewUrl(result.previewUrl)
+      const url = await prepareImageForCrop(file)
+      setCropSrc(url)
+      setCrop(undefined)
     } catch {
       setUploadError('画像の変換に失敗しました。もう一度お試しください。')
-      return
+    } finally {
+      setIsConverting(false)
     }
+  }
+
+  const onImageLoad = useCallback((e: React.SyntheticEvent<HTMLImageElement>) => {
+    const { width, height } = e.currentTarget
+    const initialCrop = centerCrop(
+      makeAspectCrop({ unit: '%', width: 90 }, width / height, width, height),
+      width,
+      height
+    )
+    setCrop(initialCrop)
+  }, [])
+
+  const handleCropConfirm = async () => {
+    if (!imgRef.current || !cropSrc) return
+    // If no crop selected, use full image
+    const activeCrop: Crop = crop ?? { unit: '%', x: 0, y: 0, width: 100, height: 100 }
     setIsParsing(true)
+    setCropSrc(null)
     try {
-      const parsed = await parseRecipeFromImage(convertedFile)
+      const file = await cropAndConvert(imgRef.current, activeCrop)
+      setImageFile(file)
+      const previewUrl = URL.createObjectURL(file)
+      setImagePreviewUrl(previewUrl)
+      const parsed = await parseRecipeFromImage(file)
       if (parsed.title !== null) setTitle(parsed.title)
       if (parsed.description !== null) setDescription(parsed.description)
       if (parsed.servings !== null) setServings(String(parsed.servings))
@@ -67,6 +139,8 @@ export default function FromPhotoPage() {
   const clearImage = () => {
     setImageFile(null)
     setImagePreviewUrl(null)
+    setCropSrc(null)
+    setCrop(undefined)
     setUploadError(null)
     setParseError(null)
   }
@@ -164,7 +238,58 @@ export default function FromPhotoPage() {
                 {uploadError}
               </p>
             )}
-            {imagePreviewUrl ? (
+
+            {/* HEIC変換中 */}
+            {isConverting && (
+              <div className="flex items-center justify-center gap-2 text-sm text-zinc-500 py-8">
+                <svg className="animate-spin h-4 w-4 text-zinc-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                画像を変換中...
+              </div>
+            )}
+
+            {/* クロップUI */}
+            {cropSrc && !isConverting && (
+              <div className="space-y-3">
+                <p className="text-sm text-zinc-500">レシピ部分をドラッグで選択してください</p>
+                <div className="w-full overflow-hidden rounded-lg bg-zinc-100">
+                  <ReactCrop
+                    crop={crop}
+                    onChange={(c) => setCrop(c)}
+                    className="w-full"
+                  >
+                    <img
+                      ref={imgRef}
+                      src={cropSrc}
+                      alt="クロップ"
+                      className="w-full"
+                      onLoad={onImageLoad}
+                    />
+                  </ReactCrop>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={handleCropConfirm}
+                    className="flex-1 py-2.5 rounded-lg bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 transition-colors"
+                  >
+                    この範囲で決定
+                  </button>
+                  <button
+                    type="button"
+                    onClick={clearImage}
+                    className="px-4 py-2.5 rounded-lg border border-zinc-300 text-sm text-zinc-600 hover:bg-zinc-50 transition-colors"
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* プレビュー（クロップ確定後） */}
+            {imagePreviewUrl && !cropSrc && (
               <div className="space-y-3">
                 <div className="w-full aspect-video rounded-lg overflow-hidden bg-zinc-100">
                   <img src={imagePreviewUrl} alt="プレビュー" className="w-full h-full object-cover" />
@@ -191,7 +316,10 @@ export default function FromPhotoPage() {
                   写真を削除
                 </button>
               </div>
-            ) : (
+            )}
+
+            {/* ファイル選択UI */}
+            {!cropSrc && !imagePreviewUrl && !isConverting && (
               <label className="flex flex-col items-center justify-center w-full h-32 rounded-lg border-2 border-dashed border-zinc-300 cursor-pointer hover:border-zinc-400 transition-colors">
                 <span className="text-sm text-zinc-500">タップして写真を選択</span>
                 <input

--- a/app/utils/imageConverter.ts
+++ b/app/utils/imageConverter.ts
@@ -1,3 +1,23 @@
+function isHeic(file: File): boolean {
+  if (file.type === 'image/heic' || file.type === 'image/heif') return true
+  const ext = file.name.split('.').pop()?.toLowerCase()
+  return ext === 'heic' || ext === 'heif'
+}
+
+export async function prepareImageForCrop(file: File): Promise<string> {
+  if (isHeic(file)) {
+    const formData = new FormData()
+    formData.append('file', file)
+    const res = await fetch('/api/images/convert', { method: 'POST', body: formData })
+    if (!res.ok) {
+      throw new Error('Failed to convert image')
+    }
+    const blob = await res.blob()
+    return URL.createObjectURL(blob)
+  }
+  return URL.createObjectURL(file)
+}
+
 export async function convertImage(file: File): Promise<{ convertedFile: File; previewUrl: string }> {
   const formData = new FormData()
   formData.append('file', file)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "puppeteer-core": "^24.38.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-image-crop": "^11.0.10",
         "sharp": "^0.34.5"
       },
       "devDependencies": {
@@ -8791,6 +8792,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
+      "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "puppeteer-core": "^24.38.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-image-crop": "^11.0.10",
     "sharp": "^0.34.5"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
Vercel上だと画像変換にローカルの10倍ほど時間がかかっていたため、アプローチを変更する

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #41

## やったこと
<!-- このPRで何をしたのか -->

- react-image-crop ライブラリ追加 — クライアントサイドのクロップUIに使用
- imageConverter.ts 修正 — HEIC/HEIFのみ /api/images/convert を呼ぶ prepareImageForCrop() を追加。それ以外は URL.createObjectURL で即座にURLを返す
- from-photo/page.tsx 改修 — 写真選択後にクロップUI（ReactCrop）を表示し、「この範囲で決定」ボタンでCanvas変換（クライアントサイドJPEG化）してから解析へ進むフローに変更
- from-photo/page.test.tsx 更新 — 新フロー（アップロード→クロップ確定→解析）に合わせてテストを書き直し、ReactCrop・Canvas API のモックを追加

効果: JPEG/PNG/WebP の場合は sharp（~25MB ネイティブバイナリ）のコールドスタートが完全に不要になり、Vercel上での「画像読み取り中」表示までの待ち時間を大幅に短縮。

## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
HEICの場合は従来通り /api/images/convert（sharp）を呼ぶので、コールドスタートの問題は残る
- iPhoneユーザー（HEIC）は頻度が高いが、クロップUI導入により「クロップ操作している間」にサーバーが暖まる可能性がある
- JPEG/PNG/WebPユーザーはコールドスタート完全排除されるので改善される
HEICのコールドスタート問題を根本解決したいなら、heic-convert（すでにpackage.jsonに入っている）をクライアントサイドでWASM経由で使うか、あるいはHEICもブラウザ側で変換するライブラリ（heic2any等）を使えば、サーバーAPI自体が不要になる
