### PR TITLE
【feature/49】sharpを削除しheic-convertのみとする

### DIFF
--- a/app/api/images/convert/route.test.ts
+++ b/app/api/images/convert/route.test.ts
@@ -1,19 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { mockSharpInstance, mockToBuffer, mockHeicTo } = vi.hoisted(() => {
-  const mockToBuffer = vi.fn()
-  const mockSharpInstance = {
-    resize: vi.fn().mockReturnThis(),
-    jpeg: vi.fn().mockReturnThis(),
-    toBuffer: mockToBuffer,
-  }
+const { mockHeicTo } = vi.hoisted(() => {
   const mockHeicTo = vi.fn()
-  return { mockSharpInstance, mockToBuffer, mockHeicTo }
+  return { mockHeicTo }
 })
-
-vi.mock('sharp', () => ({
-  default: vi.fn().mockReturnValue(mockSharpInstance),
-}))
 
 vi.mock('heic-convert', () => ({
   default: mockHeicTo,
@@ -33,34 +23,27 @@ function makeFormData(file: File) {
 describe('POST /api/images/convert', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('JPEG/PNG は sharp に直接渡して変換する', async () => {
+  it('HEIC は heicConvert でデコードして返す', async () => {
     const jpegBuffer = Buffer.from([0xff, 0xd8, 0xff])
-    mockToBuffer.mockResolvedValue(jpegBuffer)
-
-    const file = new File(['dummy'], 'photo.jpg', { type: 'image/jpeg' })
-    const res = await POST(makeFormData(file) as unknown as Request)
-
-    expect(mockHeicTo).not.toHaveBeenCalled()
-    expect(mockSharpInstance.resize).toHaveBeenCalledWith(1024, 1024, { fit: 'inside', withoutEnlargement: true })
-    expect(mockSharpInstance.jpeg).toHaveBeenCalledWith({ quality: 70 })
-    expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Type')).toBe('image/jpeg')
-  })
-
-  it('HEIC は heicConvert でデコードしてから sharp に渡す', async () => {
-    const decodedBuffer = new ArrayBuffer(4)
-    const jpegBuffer = Buffer.from([0xff, 0xd8, 0xff])
-    mockHeicTo.mockResolvedValue(decodedBuffer)
-    mockToBuffer.mockResolvedValue(jpegBuffer)
+    mockHeicTo.mockResolvedValue(jpegBuffer)
 
     const file = new File(['heic-data'], 'photo.HEIC', { type: 'image/heic' })
     const res = await POST(makeFormData(file) as unknown as Request)
 
     expect(mockHeicTo).toHaveBeenCalledWith(
-      expect.objectContaining({ format: 'JPEG', quality: 1 })
+      expect.objectContaining({ format: 'JPEG' })
     )
-    expect(mockSharpInstance.resize).toHaveBeenCalled()
     expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('image/jpeg')
+  })
+
+  it('JPEG はそのまま返す', async () => {
+    const file = new File(['dummy'], 'photo.jpg', { type: 'image/jpeg' })
+    const res = await POST(makeFormData(file) as unknown as Request)
+
+    expect(mockHeicTo).not.toHaveBeenCalled()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('image/jpeg')
   })
 
   it('ファイルがない場合は 400 を返す', async () => {
@@ -75,9 +58,9 @@ describe('POST /api/images/convert', () => {
   })
 
   it('変換失敗時は 500 を返す', async () => {
-    mockToBuffer.mockRejectedValue(new Error('sharp error'))
+    mockHeicTo.mockRejectedValue(new Error('heic-convert error'))
 
-    const file = new File(['dummy'], 'photo.jpg', { type: 'image/jpeg' })
+    const file = new File(['heic-data'], 'photo.HEIC', { type: 'image/heic' })
     const res = await POST(makeFormData(file) as unknown as Request)
 
     expect(res.status).toBe(500)

--- a/app/api/images/convert/route.ts
+++ b/app/api/images/convert/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import sharp from 'sharp'
 import heicConvert from 'heic-convert'
 
 const HEIC_TYPES = ['image/heic', 'image/heif']
@@ -20,19 +19,14 @@ export async function POST(req: NextRequest) {
       const converted = await heicConvert({
         buffer: new Uint8Array(arrayBuffer) as unknown as ArrayBuffer,
         format: 'JPEG',
-        quality: 1,
+        quality: 0.7,
       })
       buffer = Buffer.from(converted)
     } else {
       buffer = Buffer.from(arrayBuffer)
     }
 
-    const jpegBuffer = await sharp(buffer)
-      .resize(1024, 1024, { fit: 'inside', withoutEnlargement: true })
-      .jpeg({ quality: 70 })
-      .toBuffer()
-
-    return new NextResponse(new Uint8Array(jpegBuffer), {
+    return new NextResponse(new Uint8Array(buffer), {
       status: 200,
       headers: { 'Content-Type': 'image/jpeg' },
     })

--- a/app/utils/imageConverter.test.ts
+++ b/app/utils/imageConverter.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}))
+
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('URL', {
+  createObjectURL: vi.fn().mockReturnValue('blob:mock-url'),
+  revokeObjectURL: vi.fn(),
+})
+
+import { prepareImageForCrop, convertImage } from './imageConverter'
+
+function makeJpegResponse() {
+  const blob = new Blob([new Uint8Array([0xff, 0xd8, 0xff])], { type: 'image/jpeg' })
+  return Promise.resolve(new Response(blob, { status: 200 }))
+}
+
+describe('imageConverter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockReturnValue('blob:mock-url')
+  })
+
+  describe('prepareImageForCrop', () => {
+    it('HEIC は /api/images/convert に POST して Object URL を返す', async () => {
+      mockFetch.mockReturnValue(makeJpegResponse())
+
+      const file = new File(['heic-data'], 'photo.HEIC', { type: 'image/heic' })
+      const result = await prepareImageForCrop(file)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/images/convert',
+        expect.objectContaining({ method: 'POST' })
+      )
+      expect(result).toBe('blob:mock-url')
+    })
+
+    it('HEIF も /api/images/convert に POST する', async () => {
+      mockFetch.mockReturnValue(makeJpegResponse())
+
+      const file = new File(['heif-data'], 'photo.heif', { type: 'image/heif' })
+      await prepareImageForCrop(file)
+
+      expect(mockFetch).toHaveBeenCalled()
+    })
+
+    it('拡張子が .heic でも変換APIを呼ぶ（MIME type が空の場合）', async () => {
+      mockFetch.mockReturnValue(makeJpegResponse())
+
+      const file = new File(['heic-data'], 'photo.heic', { type: '' })
+      await prepareImageForCrop(file)
+
+      expect(mockFetch).toHaveBeenCalled()
+    })
+
+    it('JPEG は API を呼ばず、Object URL をそのまま返す', async () => {
+      const file = new File(['jpeg-data'], 'photo.jpg', { type: 'image/jpeg' })
+      const result = await prepareImageForCrop(file)
+
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(URL.createObjectURL).toHaveBeenCalledWith(file)
+      expect(result).toBe('blob:mock-url')
+    })
+
+    it('PNG は API を呼ばず、Object URL をそのまま返す', async () => {
+      const file = new File(['png-data'], 'photo.png', { type: 'image/png' })
+      const result = await prepareImageForCrop(file)
+
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(result).toBe('blob:mock-url')
+    })
+
+    it('API が失敗した場合はエラーを throw する', async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 500 }))
+
+      const file = new File(['heic-data'], 'photo.HEIC', { type: 'image/heic' })
+      await expect(prepareImageForCrop(file)).rejects.toThrow('Failed to convert image')
+    })
+  })
+
+  describe('convertImage', () => {
+    it('/api/images/convert に POST して File と previewUrl を返す', async () => {
+      mockFetch.mockReturnValue(makeJpegResponse())
+
+      const file = new File(['heic-data'], 'photo.HEIC', { type: 'image/heic' })
+      const { convertedFile, previewUrl } = await convertImage(file)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/images/convert',
+        expect.objectContaining({ method: 'POST' })
+      )
+      expect(convertedFile.name).toBe('photo.jpg')
+      expect(convertedFile.type).toBe('image/jpeg')
+      expect(previewUrl).toBe('blob:mock-url')
+    })
+
+    it('API が失敗した場合はエラーを throw する', async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 500 }))
+
+      const file = new File(['data'], 'photo.jpg', { type: 'image/jpeg' })
+      await expect(convertImage(file)).rejects.toThrow('Failed to convert image')
+    })
+  })
+})

--- a/app/utils/imageConverter.test.tsx
+++ b/app/utils/imageConverter.test.tsx
@@ -17,40 +17,22 @@ function makeJpegResponse() {
   return Promise.resolve(new Response(blob, { status: 200 }))
 }
 
-describe('convertImage', () => {
+describe('convertImage (component env)', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('/api/images/convert に FormData を POST する', async () => {
+  it('/api/images/convert に POST して File と blob URL を返す', async () => {
     mockFetch.mockReturnValue(makeJpegResponse())
 
     const file = new File(['heic-data'], 'photo.HEIC', { type: 'image/heic' })
-    await convertImage(file)
+    const { convertedFile, previewUrl } = await convertImage(file)
 
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/images/convert',
       expect.objectContaining({ method: 'POST' })
     )
-  })
-
-  it('変換済み File と blob URL を返す', async () => {
-    mockFetch.mockReturnValue(makeJpegResponse())
-
-    const file = new File(['data'], 'photo.HEIC', { type: 'image/heic' })
-    const { convertedFile, previewUrl } = await convertImage(file)
-
     expect(convertedFile.name).toBe('photo.jpg')
     expect(convertedFile.type).toBe('image/jpeg')
     expect(previewUrl).toBe('blob:converted')
-  })
-
-  it('PNG も変換される', async () => {
-    mockFetch.mockReturnValue(makeJpegResponse())
-
-    const file = new File(['data'], 'photo.png', { type: 'image/png' })
-    const { convertedFile } = await convertImage(file)
-
-    expect(convertedFile.type).toBe('image/jpeg')
-    expect(convertedFile.name).toBe('photo.jpg')
   })
 
   it('API が 500 を返した場合はエラーを throw する', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,7 @@
         "puppeteer-core": "^24.38.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "react-image-crop": "^11.0.10",
-        "sharp": "^0.34.5"
+        "react-image-crop": "^11.0.10"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1114,6 +1113,7 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4931,6 +4931,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -9181,6 +9182,7 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -9224,6 +9226,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "puppeteer-core": "^24.38.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-image-crop": "^11.0.10",
-    "sharp": "^0.34.5"
+    "react-image-crop": "^11.0.10"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
vercel上でsharpのネイティブバイナリによるコールドスタートで、処理時間がかかっていたのを改善

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #49 

## やったこと
<!-- このPRで何をしたのか -->
 - heic2any をインストールしてクライアントサイド変換を試みたが、ERR_LIBHEIF format not supported で失敗
  - heic2any の static import を dynamic import に変更したが改善せず
  - サーバーAPI（/api/images/convert）方式に戻す方針に変更
  - sharp を削除し heic-convert のみに絞ることでコールドスタート改善を狙う
  - app/api/images/convert/route.ts から sharp を削除（heic-convert のみで変換）
  - app/utils/imageConverter.ts を旧サーバーAPI呼び出し方式に戻す
  - sharp・heic2any をアンインストール
  - テスト一式を更新（181テスト全通過）
  - ローカル動作確認OK


## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
