### PR TITLE
【feature/53】URL読み取りの時間削減

### DIFF
--- a/app/api/recipes/parse-url/route.test.ts
+++ b/app/api/recipes/parse-url/route.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { ParsedRecipe } from '../../../types/recipe'
 
-const { mockGetUser, mockGenerateContent, mockPuppeteerLaunch } = vi.hoisted(() => {
+const { mockGetUser, mockGenerateContent, mockPuppeteerLaunch, mockFetch } = vi.hoisted(() => {
   const mockGetUser = vi.fn()
   const mockGenerateContent = vi.fn()
   const mockPuppeteerLaunch = vi.fn()
-  return { mockGetUser, mockGenerateContent, mockPuppeteerLaunch }
+  const mockFetch = vi.fn()
+  return { mockGetUser, mockGenerateContent, mockPuppeteerLaunch, mockFetch }
 })
 
 vi.mock('puppeteer', () => ({
@@ -48,10 +49,41 @@ const validParsedRecipe: ParsedRecipe = {
   steps: ['玉ねぎを炒める', 'カレールーを加える'],
 }
 
+function makeMockPage(overrides: Partial<{
+  goto: ReturnType<typeof vi.fn>
+  evaluate: ReturnType<typeof vi.fn>
+  screenshot: ReturnType<typeof vi.fn>
+}> = {}) {
+  return {
+    setDefaultNavigationTimeout: vi.fn(),
+    setRequestInterception: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(),
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue('a'.repeat(200)),
+    screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
+    setViewport: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function makeMockBrowser(mockPage: object) {
+  const mockClose = vi.fn().mockResolvedValue(undefined)
+  return {
+    browser: {
+      newPage: vi.fn().mockResolvedValue(mockPage),
+      close: mockClose,
+    },
+    mockClose,
+  }
+}
+
 describe('POST /api/recipes/parse-url', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } } })
+    // Jina がデフォルトで失敗するよう設定
+    mockFetch.mockRejectedValue(new Error('Jina fetch failed'))
+    vi.stubGlobal('fetch', mockFetch)
   })
 
   it('未認証の場合は 401 を返す', async () => {
@@ -86,18 +118,12 @@ describe('POST /api/recipes/parse-url', () => {
     expect(body.error).toBe('INVALID_URL')
   })
 
-  it('ページ取得失敗の場合は 422 を返し、browser.close が呼ばれる', async () => {
-    const mockClose = vi.fn().mockResolvedValue(undefined)
-    const mockPage2 = {
-      setDefaultNavigationTimeout: vi.fn(),
+  it('ページ取得失敗 + Jina 失敗の場合は 422 を返し、browser.close が呼ばれる', async () => {
+    const mockPage = makeMockPage({
       goto: vi.fn().mockRejectedValue(new Error('Navigation failed')),
-      evaluate: vi.fn(),
-      screenshot: vi.fn(),
-    }
-    mockPuppeteerLaunch.mockResolvedValueOnce({
-      newPage: vi.fn().mockResolvedValue(mockPage2),
-      close: mockClose,
     })
+    const { browser, mockClose } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
 
     const res = await POST(makeRequest({ url: 'https://example.com' }) as unknown as Request)
 
@@ -105,18 +131,11 @@ describe('POST /api/recipes/parse-url', () => {
     expect(mockClose).toHaveBeenCalled()
   })
 
-  it('テキスト抽出成功時: Gemini テキストプロンプトで呼ばれ 200 + ParsedRecipe を返す', async () => {
-    const mockClose = vi.fn().mockResolvedValue(undefined)
-    const mockPage2 = {
-      setDefaultNavigationTimeout: vi.fn(),
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn().mockResolvedValue('玉ねぎを炒めてカレーを作る材料: 玉ねぎ1個'),
-      screenshot: vi.fn(),
-    }
-    mockPuppeteerLaunch.mockResolvedValueOnce({
-      newPage: vi.fn().mockResolvedValue(mockPage2),
-      close: mockClose,
-    })
+  it('Jina 失敗 + Puppeteer テキスト十分: Puppeteer テキストが Gemini に渡され 200 + ParsedRecipe を返す', async () => {
+    const puppeteerText = 'a'.repeat(200)
+    const mockPage = makeMockPage({ evaluate: vi.fn().mockResolvedValue(puppeteerText) })
+    const { browser } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
     mockGenerateContent.mockResolvedValue({
       response: { text: () => JSON.stringify(validParsedRecipe) },
     })
@@ -127,23 +146,18 @@ describe('POST /api/recipes/parse-url', () => {
     expect(res.status).toBe(200)
     expect(body).toEqual(validParsedRecipe)
     expect(mockGenerateContent).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.stringContaining('玉ねぎを炒めてカレーを作る材料')])
+      expect.arrayContaining([expect.stringContaining(puppeteerText)])
     )
   })
 
-  it('テキストが 0 文字の場合: スクリーンショットで Gemini 画像入力、200 + ParsedRecipe を返す', async () => {
-    const mockClose = vi.fn().mockResolvedValue(undefined)
+  it('Jina 失敗 + Puppeteer テキスト空: スクリーンショットで Gemini 画像入力、200 + ParsedRecipe を返す', async () => {
     const screenshotBuffer = Buffer.from('fake-png-data')
-    const mockPage2 = {
-      setDefaultNavigationTimeout: vi.fn(),
-      goto: vi.fn().mockResolvedValue(undefined),
+    const mockPage = makeMockPage({
       evaluate: vi.fn().mockResolvedValue(''),
       screenshot: vi.fn().mockResolvedValue(screenshotBuffer),
-    }
-    mockPuppeteerLaunch.mockResolvedValueOnce({
-      newPage: vi.fn().mockResolvedValue(mockPage2),
-      close: mockClose,
     })
+    const { browser } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
     mockGenerateContent.mockResolvedValue({
       response: { text: () => JSON.stringify(validParsedRecipe) },
     })
@@ -159,17 +173,9 @@ describe('POST /api/recipes/parse-url', () => {
   })
 
   it('Gemini が invalid JSON を返す場合は 500 を返す', async () => {
-    const mockClose = vi.fn().mockResolvedValue(undefined)
-    const mockPage2 = {
-      setDefaultNavigationTimeout: vi.fn(),
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn().mockResolvedValue('some text'),
-      screenshot: vi.fn(),
-    }
-    mockPuppeteerLaunch.mockResolvedValueOnce({
-      newPage: vi.fn().mockResolvedValue(mockPage2),
-      close: mockClose,
-    })
+    const mockPage = makeMockPage()
+    const { browser } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
     mockGenerateContent.mockResolvedValue({
       response: { text: () => 'これはJSONではない' },
     })
@@ -180,17 +186,9 @@ describe('POST /api/recipes/parse-url', () => {
   })
 
   it('Gemini API が例外を投げる場合は 500 を返す', async () => {
-    const mockClose = vi.fn().mockResolvedValue(undefined)
-    const mockPage2 = {
-      setDefaultNavigationTimeout: vi.fn(),
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn().mockResolvedValue('some text'),
-      screenshot: vi.fn(),
-    }
-    mockPuppeteerLaunch.mockResolvedValueOnce({
-      newPage: vi.fn().mockResolvedValue(mockPage2),
-      close: mockClose,
-    })
+    const mockPage = makeMockPage()
+    const { browser } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
     mockGenerateContent.mockRejectedValue(new Error('API error'))
 
     const res = await POST(makeRequest({ url: 'https://example.com' }) as unknown as Request)
@@ -199,21 +197,87 @@ describe('POST /api/recipes/parse-url', () => {
   })
 
   it('エラー時も browser.close が呼ばれる (finally)', async () => {
-    const mockClose = vi.fn().mockResolvedValue(undefined)
-    const mockPage2 = {
-      setDefaultNavigationTimeout: vi.fn(),
-      goto: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn().mockResolvedValue('some text'),
-      screenshot: vi.fn(),
-    }
-    mockPuppeteerLaunch.mockResolvedValueOnce({
-      newPage: vi.fn().mockResolvedValue(mockPage2),
-      close: mockClose,
-    })
+    const mockPage = makeMockPage()
+    const { browser, mockClose } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
     mockGenerateContent.mockRejectedValue(new Error('API error'))
 
     await POST(makeRequest({ url: 'https://example.com' }) as unknown as Request)
 
     expect(mockClose).toHaveBeenCalled()
+  })
+
+  // 並列実行テスト
+  it('Jina が先に十分なテキストを返した場合: Jina テキストが Gemini に渡され 200 + ParsedRecipe を返す', async () => {
+    const jinaText = 'a'.repeat(200)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(jinaText),
+    })
+    const mockPage = makeMockPage()
+    const { browser, mockClose } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => JSON.stringify(validParsedRecipe) },
+    })
+
+    const res = await POST(makeRequest({ url: 'https://example.com' }) as unknown as Request)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual(validParsedRecipe)
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining(jinaText)])
+    )
+    // Jina 成功でも browser.close が呼ばれる
+    expect(mockClose).toHaveBeenCalled()
+  })
+
+  it('Jina テキスト不十分 + Puppeteer テキスト十分: Puppeteer テキストが Gemini に渡される', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('a'.repeat(199)),
+    })
+    const puppeteerText = 'a'.repeat(200)
+    const mockPage = makeMockPage({ evaluate: vi.fn().mockResolvedValue(puppeteerText) })
+    const { browser } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => JSON.stringify(validParsedRecipe) },
+    })
+
+    const res = await POST(makeRequest({ url: 'https://example.com' }) as unknown as Request)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual(validParsedRecipe)
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining(puppeteerText)])
+    )
+  })
+
+  it('両方テキスト不十分: スクリーンショット + Vision API、setViewport が呼ばれる', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('a'.repeat(199)),
+    })
+    const screenshotBuffer = Buffer.from('fake-png-data')
+    const mockPage = makeMockPage({
+      evaluate: vi.fn().mockResolvedValue(''),
+      screenshot: vi.fn().mockResolvedValue(screenshotBuffer),
+    })
+    const { browser } = makeMockBrowser(mockPage)
+    mockPuppeteerLaunch.mockResolvedValueOnce(browser)
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => JSON.stringify(validParsedRecipe) },
+    })
+
+    const res = await POST(makeRequest({ url: 'https://example.com' }) as unknown as Request)
+
+    expect(res.status).toBe(200)
+    expect(mockPage.setViewport).toHaveBeenCalledWith({ width: 1200, height: 1800 })
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ inlineData: expect.objectContaining({ mimeType: 'image/png' }) })])
+    )
   })
 })

--- a/app/api/recipes/parse-url/route.ts
+++ b/app/api/recipes/parse-url/route.ts
@@ -5,6 +5,9 @@ import { createClient } from '../../../utils/supabase/server'
 const CHROMIUM_REMOTE_URL =
   'https://github.com/Sparticuz/chromium/releases/download/v143.0.4/chromium-v143.0.4-pack.x64.tar'
 
+const MIN_TEXT_LENGTH = 200
+const MAX_TEXT_LENGTH = 8000
+
 async function launchBrowser() {
   if (process.env.VERCEL) {
     const chromium = await import('@sparticuz/chromium-min')
@@ -57,6 +60,79 @@ const IMAGE_PROMPT = `この画像はレシピページのスクリーンショ�
 材料の量と単位が分離できない場合（例:「適量」）は amount にそのまま入れ unit は空文字にしてください。
 手順は配列の順序通りに並べてください。`
 
+async function fetchViaJina(url: string): Promise<string> {
+  const jinaUrl = `https://r.jina.ai/${url}`
+  const res = await fetch(jinaUrl, {
+    headers: { 'Accept': 'text/plain' },
+    signal: AbortSignal.timeout(5000),
+  })
+  if (!res.ok) throw new Error(`Jina fetch failed: ${res.status}`)
+  return res.text()
+}
+
+async function sendToGemini(content: string | Buffer, type: 'text' | 'image') {
+  const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GENERATIVE_AI_API_KEY!)
+  const modelName = process.env.GEMINI_MODEL ?? 'gemini-2.5-flash-lite'
+  const model = genAI.getGenerativeModel({ model: modelName })
+
+  let result
+  if (type === 'image') {
+    const base64 = (content as Buffer).toString('base64')
+    result = await model.generateContent([
+      IMAGE_PROMPT,
+      { inlineData: { mimeType: 'image/png', data: base64 } },
+    ])
+  } else {
+    const truncated = (content as string).slice(0, MAX_TEXT_LENGTH)
+    result = await model.generateContent([TEXT_PROMPT + truncated])
+  }
+
+  const text = result.response.text().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim()
+  return JSON.parse(text)
+}
+
+// 十分なテキストを返した方を先着で解決するPromise
+// 両方失敗 or 両方テキスト不十分の場合は null を返す
+function raceFirstSufficientText(
+  jinaPromise: Promise<string>,
+  puppeteerPromise: Promise<string>,
+  log: (msg: string) => void,
+): Promise<{ source: 'jina' | 'puppeteer'; text: string } | null> {
+  return new Promise((resolve) => {
+    let settled = 0
+    let resolved = false
+    const total = 2
+
+    const tryResolve = (source: 'jina' | 'puppeteer', text: string) => {
+      settled++
+      if (!resolved && text.length >= MIN_TEXT_LENGTH) {
+        resolved = true
+        log(`${source} won the race (${text.length} chars)`)
+        resolve({ source, text })
+      } else if (settled === total && !resolved) {
+        // 両方終わったがどちらも不十分
+        resolve(null)
+      }
+    }
+
+    jinaPromise
+      .then((text) => tryResolve('jina', text))
+      .catch((err) => {
+        log(`Jina failed: ${err}`)
+        settled++
+        if (settled === total && !resolved) resolve(null)
+      })
+
+    puppeteerPromise
+      .then((text) => tryResolve('puppeteer', text))
+      .catch((err) => {
+        log(`Puppeteer failed: ${err}`)
+        settled++
+        if (settled === total && !resolved) resolve(null)
+      })
+  })
+}
+
 export const maxDuration = 60
 
 export async function POST(req: NextRequest) {
@@ -84,46 +160,76 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'INVALID_URL' }, { status: 400 })
   }
 
+  const t0 = Date.now()
+  const elapsed = () => `${Date.now() - t0}ms`
+  const log = (msg: string) => console.log(`[parse-url] ${msg} elapsed=${elapsed()}`)
+
+  log(`start url=${url}`)
+
   const browser = await launchBrowser()
+  log('browser launched')
+
   try {
     const page = await browser.newPage()
     page.setDefaultNavigationTimeout(30000)
+    await page.setRequestInterception(true)
+    page.on('request', (req: { resourceType: () => string; abort: () => void; continue: () => void }) => {
+      const blocked = ['image', 'stylesheet', 'font', 'media']
+      if (blocked.includes(req.resourceType())) {
+        req.abort()
+      } else {
+        req.continue()
+      }
+    })
 
-    try {
-      await page.goto(url, { waitUntil: 'networkidle2' })
-    } catch {
+    const jinaPromise = (async () => {
+      log('Jina fetch start')
+      const text = await fetchViaJina(url)
+      log(`Jina fetch done textLength=${text.length}`)
+      return text
+    })()
+
+    const puppeteerPromise = (async () => {
+      log('Puppeteer page.goto start')
+      await page.goto(url, { waitUntil: 'domcontentloaded' })
+      log('Puppeteer page.goto done')
+      const text: string = await page.evaluate(() => {
+        const selectors = 'header, footer, nav, aside, script, style, noscript, iframe'
+        document.querySelectorAll(selectors).forEach((el) => el.remove())
+        return (document.body?.innerText ?? '')
+          .split('\n')
+          .map((line: string) => line.trim())
+          .filter((line: string) => line.length > 0)
+          .join('\n')
+      })
+      log(`Puppeteer evaluate done textLength=${text.length}`)
+      return text
+    })()
+
+    const winner = await raceFirstSufficientText(jinaPromise, puppeteerPromise, log)
+
+    if (winner) {
+      const parsed = await sendToGemini(winner.text, 'text')
+      log(`Gemini done (source=${winner.source})`)
+      return NextResponse.json(parsed, { status: 200 })
+    }
+
+    // 両方テキスト不十分 → Puppeteer が失敗していた場合は 422
+    const puppeteerResult = await puppeteerPromise.catch((err) => err)
+    if (puppeteerResult instanceof Error) {
+      log(`both failed, Puppeteer error: ${puppeteerResult}`)
       return NextResponse.json({ error: 'URL_FETCH_FAILED' }, { status: 422 })
     }
 
-    const scrapedText: string = await page.evaluate(() => {
-      const selectors = 'header, footer, nav, aside, script, style, noscript, iframe'
-      document.querySelectorAll(selectors).forEach((el) => el.remove())
-      return (document.body?.innerText ?? '')
-        .split('\n')
-        .map((line: string) => line.trim())
-        .filter((line: string) => line.length > 0)
-        .join('\n')
-    })
-
-    const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GENERATIVE_AI_API_KEY!)
-    const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' })
-
-    let result
-    if (scrapedText.length === 0) {
-      const screenshotBuffer = await page.screenshot({ fullPage: true, type: 'png' }) as Buffer
-      const base64 = screenshotBuffer.toString('base64')
-      result = await model.generateContent([
-        IMAGE_PROMPT,
-        { inlineData: { mimeType: 'image/png', data: base64 } },
-      ])
-    } else {
-      result = await model.generateContent([TEXT_PROMPT + scrapedText])
-    }
-
-    const text = result.response.text().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim()
-    const parsed = JSON.parse(text)
-
+    // スクリーンショット + Gemini Vision
+    log('both text insufficient, taking screenshot')
+    await page.setViewport({ width: 1200, height: 1800 })
+    const screenshotBuffer = await page.screenshot({ fullPage: true, type: 'png' }) as Buffer
+    log('screenshot done')
+    const parsed = await sendToGemini(screenshotBuffer, 'image')
+    log('Gemini done (source=screenshot)')
     return NextResponse.json(parsed, { status: 200 })
+
   } catch (err) {
     console.error('Recipe URL parse error:', err)
     return NextResponse.json({ error: 'Failed to parse recipe' }, { status: 500 })


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
URL読み取りに15〜30秒程度かかっていたので、原因特定と修正を行った

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #53 

## やったこと
<!-- このPRで何をしたのか -->
-   フォールバック設計の導入
- Jina AI Reader → Puppeteerテキスト → スクリーンショットの3段階フォールバックを実装
- waitUntil: 'networkidle2' → domcontentloaded に変更
- Puppeteerで画像・CSS・フォント・メディアをリクエストブロック

ログ追加
- 各Phaseの開始・終了タイミングと経過時間をログ出力
- どこで時間がかかっているかを特定できるようにした

Geminiに送るテキストの切り詰め
- 27,000文字などの長文をそのまま送っていた → 8,000文字に上限設定

JinaとPuppeteerの並列実行
- 直列（Jina完了後にPuppeteer起動）→ 並列（同時スタート）に変更
- 先に十分なテキスト（200文字以上）を返した方を採用、もう片方はキャンセル

Geminiモデルの変更
- gemini-2.5-flash（思考モードで遅い）→ gemini-2.5-flash-lite に変更

細かい修正
- Jinaのタイムアウト 10秒 → 5秒
- raceのバグ修正（勝者決定後も「won the race」ログが出ていた）
- Geminiモデルを GEMINI_MODEL 環境変数で切り替え可能に

## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認
  - 結果delish kitchen：7秒、cookpad：4.4秒、kurashiru：5.2秒

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
