### PR TITLE
【feature/59】urlからのレシピを削除したときにバケットからも削除されるように修正

### DIFF
--- a/app/api/recipes/parse-url/route.ts
+++ b/app/api/recipes/parse-url/route.ts
@@ -73,7 +73,7 @@ async function fetchViaJina(url: string): Promise<string> {
 
 async function sendToGemini(content: string | Buffer, type: 'text' | 'image') {
   const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GENERATIVE_AI_API_KEY!)
-  const modelName = process.env.GEMINI_MODEL || 'gemini-2.5-flash-lite'
+  const modelName = process.env.GEMINI_MODEL!
   const model = genAI.getGenerativeModel({ model: modelName })
 
   let result

--- a/app/api/recipes/parse/route.test.ts
+++ b/app/api/recipes/parse/route.test.ts
@@ -7,18 +7,21 @@ const { mockGetUser, mockGenerateContent } = vi.hoisted(() => {
   return { mockGetUser, mockGenerateContent }
 })
 
+
 vi.mock('../../../utils/supabase/server', () => ({
   createClient: vi.fn().mockResolvedValue({
     auth: { getUser: mockGetUser },
   }),
 }))
 
+const { mockGetGenerativeModel } = vi.hoisted(() => ({
+  mockGetGenerativeModel: vi.fn(),
+}))
+
 vi.mock('@google/generative-ai', () => {
   function GoogleGenerativeAI() {
     return {
-      getGenerativeModel: vi.fn().mockReturnValue({
-        generateContent: mockGenerateContent,
-      }),
+      getGenerativeModel: mockGetGenerativeModel,
     }
   }
   return { GoogleGenerativeAI }
@@ -48,6 +51,19 @@ describe('POST /api/recipes/parse', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } } })
+    mockGetGenerativeModel.mockReturnValue({ generateContent: mockGenerateContent })
+  })
+
+  it('GEMINI_MODEL 環境変数のモデルが使われる', async () => {
+    process.env.GEMINI_MODEL = 'gemini-3.1-flash-lite-preview'
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => JSON.stringify(validParsedRecipe) },
+    })
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await POST(makeRequest(file) as unknown as Request)
+
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-3.1-flash-lite-preview' })
   })
 
   it('未認証の場合は 401 を返す', async () => {

--- a/app/api/recipes/parse/route.ts
+++ b/app/api/recipes/parse/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: NextRequest) {
     const base64 = Buffer.from(arrayBuffer).toString('base64')
 
     const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GENERATIVE_AI_API_KEY!)
-    const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' })
+    const model = genAI.getGenerativeModel({ model: process.env.GEMINI_MODEL! })
 
     const result = await model.generateContent([
       PROMPT,

--- a/app/recipes/[id]/edit/EditRecipeForm.tsx
+++ b/app/recipes/[id]/edit/EditRecipeForm.tsx
@@ -109,7 +109,7 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
             setUploadError('セッションが切れました。再ログインしてください。')
             return
           }
-          const path = `${user.id}/${crypto.randomUUID()}.jpg`
+          const path = `photos/${user.id}/${crypto.randomUUID()}.jpg`
           const { error: uploadErr } = await supabase.storage.from('recipe-images').upload(path, imageFile)
           if (uploadErr) {
             setUploadError('写真のアップロードに失敗しました。もう一度お試しください。')

--- a/app/recipes/[id]/edit/page.test.tsx
+++ b/app/recipes/[id]/edit/page.test.tsx
@@ -69,7 +69,7 @@ describe('EditRecipeForm', () => {
     render(
       <EditRecipeForm
         recipeId="recipe-1"
-        initialValues={{ ...defaultInitialValues, imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/user-1/photo.jpg' }}
+        initialValues={{ ...defaultInitialValues, imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/photo.jpg' }}
       />
     )
 
@@ -90,8 +90,8 @@ describe('EditRecipeForm', () => {
 
   it('写真付きで送信すると storage.upload が呼ばれ updateRecipe に imageUrl が渡される', async () => {
     const user = userEvent.setup()
-    mockSupabaseUpload.mockResolvedValue({ data: { path: 'user-1/uuid.jpg' }, error: null })
-    mockSupabaseGetPublicUrl.mockReturnValue({ data: { publicUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/user-1/uuid.jpg' } })
+    mockSupabaseUpload.mockResolvedValue({ data: { path: 'photos/user-1/uuid.jpg' }, error: null })
+    mockSupabaseGetPublicUrl.mockReturnValue({ data: { publicUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg' } })
     mockUpdateRecipe.mockResolvedValue(undefined)
     render(<EditRecipeForm recipeId="recipe-1" initialValues={defaultInitialValues} />)
 
@@ -103,7 +103,7 @@ describe('EditRecipeForm', () => {
       expect(mockSupabaseUpload).toHaveBeenCalled()
       expect(mockUpdateRecipe).toHaveBeenCalledWith(
         'recipe-1',
-        expect.objectContaining({ imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/user-1/uuid.jpg' })
+        expect.objectContaining({ imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg' })
       )
     })
   })

--- a/app/recipes/actions.test.ts
+++ b/app/recipes/actions.test.ts
@@ -16,6 +16,8 @@ const {
   mockTransaction,
   mockRedirect,
   mockStorageRemove,
+  mockStorageUpload,
+  mockStorageGetPublicUrl,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockRecipeCreate: vi.fn(),
@@ -32,13 +34,19 @@ const {
   mockTransaction: vi.fn(),
   mockRedirect: vi.fn(),
   mockStorageRemove: vi.fn(),
+  mockStorageUpload: vi.fn(),
+  mockStorageGetPublicUrl: vi.fn(),
 }))
 
 vi.mock('../utils/supabase/server', () => ({
   createClient: vi.fn().mockResolvedValue({
     auth: { getUser: mockGetUser },
     storage: {
-      from: vi.fn().mockReturnValue({ remove: mockStorageRemove }),
+      from: vi.fn().mockReturnValue({
+        remove: mockStorageRemove,
+        upload: mockStorageUpload,
+        getPublicUrl: mockStorageGetPublicUrl,
+      }),
     },
   }),
 }))
@@ -56,6 +64,14 @@ vi.mock('../../lib/prisma', () => ({
 
 vi.mock('next/navigation', () => ({
   redirect: mockRedirect,
+}))
+
+vi.mock('sharp', () => ({
+  default: vi.fn().mockReturnValue({
+    resize: vi.fn().mockReturnThis(),
+    jpeg: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-image')),
+  }),
 }))
 
 import { createRecipe, deleteRecipe, updateRecipe } from './actions'
@@ -222,16 +238,47 @@ describe('createRecipe', () => {
     ])
   })
 
-  it('imageUrl が渡された場合: sourceType が photo になる', async () => {
+  it('外部imageUrlのfetchが失敗した場合: imageUrlがnullになる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({ ok: false } as Response)
 
-    await createRecipe({ ...baseInput, imageUrl: 'https://example.com/photo.jpg' })
+    await createRecipe({ ...baseInput, imageUrl: 'https://example.com/photo.jpg', sourceType: 'url', sourceUrl: 'https://example.com/recipe' })
 
+    // fetch失敗時はimageUrlがnullになるが、sourceTypeはurlのまま
     expect(mockRecipeCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          imageUrl: 'https://example.com/photo.jpg',
+          imageUrl: null,
+          sourceType: 'url',
+        }),
+      })
+    )
+  })
+
+  it('外部imageUrlのバケット保存が成功した場合: バケットURLとsourceType photoで保存される', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    } as unknown as Response)
+    mockStorageUpload.mockResolvedValue({ error: null })
+    mockStorageGetPublicUrl.mockReturnValue({
+      data: { publicUrl: 'https://project.supabase.co/storage/v1/object/public/recipe-images/url-imports/user-1/uuid.jpg' },
+    })
+
+    await createRecipe({ ...baseInput, imageUrl: 'https://example.com/photo.jpg' })
+
+    expect(mockStorageUpload).toHaveBeenCalledWith(
+      expect.stringMatching(/^url-imports\/user-1\/.+\.jpg$/),
+      expect.anything(),
+      expect.anything()
+    )
+    expect(mockRecipeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          imageUrl: 'https://project.supabase.co/storage/v1/object/public/recipe-images/url-imports/user-1/uuid.jpg',
           sourceType: 'photo',
         }),
       })
@@ -507,5 +554,21 @@ describe('deleteRecipe', () => {
     await deleteRecipe('recipe-1')
 
     expect(mockStorageRemove).not.toHaveBeenCalled()
+  })
+
+  it('url-imports パスの画像がある場合: バケットから正しいパスで削除する', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({
+      id: 'recipe-1',
+      userId: 'user-1',
+      imageUrl: 'https://project.supabase.co/storage/v1/object/public/recipe-images/url-imports/user-1/uuid.jpg',
+    })
+    mockRecipeDelete.mockResolvedValue({})
+    mockStorageRemove.mockResolvedValue({ error: null })
+
+    await deleteRecipe('recipe-1')
+
+    expect(mockStorageRemove).toHaveBeenCalledWith(['url-imports/user-1/uuid.jpg'])
+    expect(mockRecipeDelete).toHaveBeenCalledWith({ where: { id: 'recipe-1' } })
   })
 })

--- a/app/recipes/actions.ts
+++ b/app/recipes/actions.ts
@@ -55,14 +55,18 @@ export async function createRecipe(input: CreateRecipeInput) {
           .resize(800, 800, { fit: 'inside', withoutEnlargement: true })
           .jpeg({ quality: 80 })
           .toBuffer()
-        const filePath = `url-imports/${randomUUID()}.jpg`
+        const filePath = `url-imports/${user.id}/${randomUUID()}.jpg`
         const { error } = await supabase.storage
           .from('recipe-images')
           .upload(filePath, resized, { contentType: 'image/jpeg', upsert: false })
         if (!error) {
           const { data } = supabase.storage.from('recipe-images').getPublicUrl(filePath)
           resolvedImageUrl = data.publicUrl
+        } else {
+          resolvedImageUrl = null
         }
+      } else {
+        resolvedImageUrl = null
       }
     } catch {
       // 画像保存失敗時は null にする

--- a/app/recipes/new/from-photo/page.tsx
+++ b/app/recipes/new/from-photo/page.tsx
@@ -188,7 +188,7 @@ export default function FromPhotoPage() {
             setUploadError('セッションが切れました。再ログインしてください。')
             return
           }
-          const path = `${user.id}/${crypto.randomUUID()}.jpg`
+          const path = `photos/${user.id}/${crypto.randomUUID()}.jpg`
           const { error: uploadErr } = await supabase.storage.from('recipe-images').upload(path, imageFile)
           if (uploadErr) {
             console.error('Storageアップロードエラー:', uploadErr)

--- a/app/recipes/new/page.test.tsx
+++ b/app/recipes/new/page.test.tsx
@@ -69,8 +69,8 @@ describe('NewRecipePage', () => {
 
   it('写真付きで送信すると storage.upload が呼ばれ createRecipe に imageUrl が渡される', async () => {
     const user = userEvent.setup()
-    mockSupabaseUpload.mockResolvedValue({ data: { path: 'user-1/uuid.jpg' }, error: null })
-    mockSupabaseGetPublicUrl.mockReturnValue({ data: { publicUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/user-1/uuid.jpg' } })
+    mockSupabaseUpload.mockResolvedValue({ data: { path: 'photos/user-1/uuid.jpg' }, error: null })
+    mockSupabaseGetPublicUrl.mockReturnValue({ data: { publicUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg' } })
     mockCreateRecipe.mockResolvedValue(undefined)
     render(<NewRecipePage />)
 
@@ -82,7 +82,7 @@ describe('NewRecipePage', () => {
     await waitFor(() => {
       expect(mockSupabaseUpload).toHaveBeenCalled()
       expect(mockCreateRecipe).toHaveBeenCalledWith(
-        expect.objectContaining({ imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/user-1/uuid.jpg' })
+        expect.objectContaining({ imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg' })
       )
     })
   })

--- a/app/recipes/new/page.tsx
+++ b/app/recipes/new/page.tsx
@@ -93,7 +93,7 @@ export default function NewRecipePage() {
             setUploadError('セッションが切れました。再ログインしてください。')
             return
           }
-          const path = `${user.id}/${crypto.randomUUID()}.jpg`
+          const path = `photos/${user.id}/${crypto.randomUUID()}.jpg`
           const { error: uploadErr } = await supabase.storage.from('recipe-images').upload(path, imageFile)
           if (uploadErr) {
             console.error('Storageアップロードエラー:', uploadErr)


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
urlから登録したレシピを削除してもバケットに画像が残り続けていたため修正
原因
- バケットのINSERTポリシーが (storage.foldername(name))[1] = auth.uid() だったため、url-imports/{uuid}.jpg というパス（第1階層が url-imports）ではポリシーに引っかかり削除できなかった
- remove() がエラーなし・空振りで返るため気づきにくかった

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #59 

## やったこと
<!-- このPRで何をしたのか -->
コード修正
- URL登録の画像保存パスを url-imports/{uuid}.jpg → url-imports/{userId}/{uuid}.jpg に変更（actions.ts）
- 写真登録の画像保存パスを {userId}/{uuid}.jpg → photos/{userId}/{uuid}.jpg に変更（new/page.tsx, from-photo/page.tsx, edit/EditRecipeForm.tsx）
- createRecipe で外部URLのfetch失敗・upload失敗時に resolvedImageUrl が外部URLのまま残るバグを修正（null を明示的にセット）

Supabaseポリシー修正
- INSERT/DELETE ポリシーの (storage.foldername(name))[1] を [2] に変更し、photos/{userId}/ と url-imports/{userId}/ の両方に対応
- 古い name ~~ 'url-imports/%' のINSERTポリシーを削除

## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->

その他わかったこと
- Publicバケットのためファイル削除後もCDNキャッシュにより画像がしばらく表示され続ける