### PR TITLE
【feature/63】複数枚の画像を抽出できるように変更

### DIFF
--- a/app/api/recipes/parse/route.test.ts
+++ b/app/api/recipes/parse/route.test.ts
@@ -38,6 +38,17 @@ function makeRequest(file?: File) {
   })
 }
 
+function makeRequestWithImages(files: File[]) {
+  const formData = new FormData()
+  for (const file of files) {
+    formData.append('images[]', file)
+  }
+  return new Request('http://localhost/api/recipes/parse', {
+    method: 'POST',
+    body: formData,
+  })
+}
+
 const validParsedRecipe: ParsedRecipe = {
   title: 'カレーライス',
   description: '定番カレー',
@@ -134,5 +145,49 @@ describe('POST /api/recipes/parse', () => {
     const res = await POST(makeRequest(file) as unknown as Request)
 
     expect(res.status).toBe(500)
+  })
+
+  describe('images[] (multi-image) サポート', () => {
+    it('2枚の画像を送ると generateContent が [PROMPT, inlineData1, inlineData2] で呼ばれる', async () => {
+      mockGenerateContent.mockResolvedValue({
+        response: { text: () => JSON.stringify(validParsedRecipe) },
+      })
+
+      const file1 = new File(['aaa'], 'photo1.jpg', { type: 'image/jpeg' })
+      const file2 = new File(['bbb'], 'photo2.png', { type: 'image/png' })
+      const res = await POST(makeRequestWithImages([file1, file2]) as unknown as Request)
+
+      expect(res.status).toBe(200)
+      expect(mockGenerateContent).toHaveBeenCalledOnce()
+      const callArgs = mockGenerateContent.mock.calls[0][0]
+      expect(callArgs).toHaveLength(3) // PROMPT + 2 inlineData parts
+      expect(typeof callArgs[0]).toBe('string') // PROMPT
+      expect(callArgs[1]).toMatchObject({ inlineData: { mimeType: 'image/jpeg' } })
+      expect(callArgs[2]).toMatchObject({ inlineData: { mimeType: 'image/png' } })
+    })
+
+    it('images[] に 1 枚送ると通常通り 200 を返す', async () => {
+      mockGenerateContent.mockResolvedValue({
+        response: { text: () => JSON.stringify(validParsedRecipe) },
+      })
+
+      const file = new File(['aaa'], 'photo.jpg', { type: 'image/jpeg' })
+      const res = await POST(makeRequestWithImages([file]) as unknown as Request)
+
+      expect(res.status).toBe(200)
+      const callArgs = mockGenerateContent.mock.calls[0][0]
+      expect(callArgs).toHaveLength(2) // PROMPT + 1 inlineData
+    })
+
+    it('image も images[] もない場合は 400 を返す', async () => {
+      const formData = new FormData()
+      const req = new Request('http://localhost/api/recipes/parse', {
+        method: 'POST',
+        body: formData,
+      })
+      const res = await POST(req as unknown as Request)
+
+      expect(res.status).toBe(400)
+    })
   })
 })

--- a/app/api/recipes/parse/route.ts
+++ b/app/api/recipes/parse/route.ts
@@ -28,21 +28,30 @@ export async function POST(req: NextRequest) {
     }
 
     const formData = await req.formData()
-    const image = formData.get('image')
-    if (!image || !(image instanceof File)) {
+
+    // Support both multi-image (images[]) and legacy single-image (image) fields
+    const multiImages = formData.getAll('images[]').filter((v): v is File => v instanceof File)
+    const legacyImage = formData.get('image')
+    const images: File[] = multiImages.length > 0
+      ? multiImages
+      : legacyImage instanceof File ? [legacyImage] : []
+
+    if (images.length === 0) {
       return NextResponse.json({ error: 'No image provided' }, { status: 400 })
     }
 
-    const arrayBuffer = await image.arrayBuffer()
-    const base64 = Buffer.from(arrayBuffer).toString('base64')
+    const inlineParts = await Promise.all(
+      images.map(async (img) => {
+        const arrayBuffer = await img.arrayBuffer()
+        const base64 = Buffer.from(arrayBuffer).toString('base64')
+        return { inlineData: { mimeType: img.type || 'image/jpeg', data: base64 } }
+      })
+    )
 
     const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GENERATIVE_AI_API_KEY!)
     const model = genAI.getGenerativeModel({ model: process.env.GEMINI_MODEL! })
 
-    const result = await model.generateContent([
-      PROMPT,
-      { inlineData: { mimeType: image.type || 'image/jpeg', data: base64 } },
-    ])
+    const result = await model.generateContent([PROMPT, ...inlineParts])
 
     const text = result.response.text().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim()
     const parsed = JSON.parse(text)

--- a/app/calendar/[date]/MealDateClient.test.tsx
+++ b/app/calendar/[date]/MealDateClient.test.tsx
@@ -25,7 +25,7 @@ const makeRecipe = (id: string, title: string) => ({
   description: null,
   servings: null,
   cookTime: null,
-  imageUrl: null,
+  images: [] as Array<{ url: string; isMain: boolean; order: number }>,
   categories: [] as Array<{ category: { id: string; name: string } }>,
 })
 

--- a/app/calendar/[date]/MealDateClient.tsx
+++ b/app/calendar/[date]/MealDateClient.tsx
@@ -12,7 +12,7 @@ type Recipe = {
   description: string | null
   servings: number | null
   cookTime: number | null
-  imageUrl: string | null
+  images: Array<{ url: string; isMain: boolean; order: number }>
   categories: Array<{ category: { id: string; name: string } }>
 }
 
@@ -119,9 +119,9 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
                     href={`/recipes/${r.recipeId}`}
                     className="flex flex-col bg-white rounded-xl border border-zinc-200 hover:border-zinc-400 transition-colors overflow-hidden h-full"
                   >
-                    {recipe?.imageUrl ? (
+                    {recipe?.images[0]?.url ? (
                       <div className="relative aspect-square w-full">
-                        <Image src={recipe.imageUrl} alt={r.recipe.title} fill className="object-cover" sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw" />
+                        <Image src={recipe.images[0].url} alt={r.recipe.title} fill className="object-cover" sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw" />
                       </div>
                     ) : (
                       <div className="aspect-square w-full bg-zinc-100 flex items-center justify-center">
@@ -188,9 +188,9 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
               return (
                 <li key={recipe.id} className="relative">
                   <div className="flex flex-col bg-white rounded-xl border border-zinc-200 overflow-hidden h-full">
-                    {recipe.imageUrl ? (
+                    {recipe.images[0]?.url ? (
                       <div className="relative aspect-square w-full">
-                        <Image src={recipe.imageUrl} alt={recipe.title} fill className="object-cover" sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw" />
+                        <Image src={recipe.images[0].url} alt={recipe.title} fill className="object-cover" sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw" />
                       </div>
                     ) : (
                       <div className="aspect-square w-full bg-zinc-100 flex items-center justify-center">

--- a/app/calendar/[date]/page.tsx
+++ b/app/calendar/[date]/page.tsx
@@ -33,7 +33,7 @@ export default async function CalendarDatePage({ params }: Props) {
         description: true,
         servings: true,
         cookTime: true,
-        imageUrl: true,
+        images: { where: { isMain: true }, take: 1 },
         categories: { include: { category: true } },
       },
     }),

--- a/app/components/HomeTabs.tsx
+++ b/app/components/HomeTabs.tsx
@@ -13,7 +13,7 @@ type Recipe = {
   description: string | null
   servings: number | null
   cookTime: number | null
-  imageUrl: string | null
+  images: Array<{ url: string; isMain: boolean; order: number }>
   categories: Array<{ category: { id: string; name: string } }>
 }
 

--- a/app/components/RecipeList.test.tsx
+++ b/app/components/RecipeList.test.tsx
@@ -8,7 +8,8 @@ const makeRecipe = (overrides = {}) => ({
   description: null,
   servings: null,
   cookTime: null,
-  categories: [],
+  images: [] as Array<{ url: string; isMain: boolean; order: number }>,
+  categories: [] as Array<{ category: { id: string; name: string } }>,
   ...overrides,
 })
 

--- a/app/components/RecipeList.tsx
+++ b/app/components/RecipeList.tsx
@@ -7,7 +7,7 @@ type Recipe = {
   description: string | null
   servings: number | null
   cookTime: number | null
-  imageUrl: string | null
+  images: Array<{ url: string; isMain: boolean; order: number }>
   categories: Array<{ category: { id: string; name: string } }>
 }
 
@@ -33,10 +33,10 @@ export default function RecipeList({ recipes }: RecipeListProps) {
             href={`/recipes/${recipe.id}`}
             className="flex flex-col bg-white rounded-xl border border-zinc-200 hover:border-zinc-400 transition-colors overflow-hidden h-full"
           >
-            {recipe.imageUrl ? (
+            {recipe.images[0]?.url ? (
               <div className="relative aspect-square w-full">
                 <Image
-                  src={recipe.imageUrl}
+                  src={recipe.images[0].url}
                   alt={recipe.title}
                   fill
                   className="object-cover"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ export default async function Home() {
         description: true,
         servings: true,
         cookTime: true,
-        imageUrl: true,
+        images: { where: { isMain: true }, take: 1 },
         categories: { include: { category: true } },
       },
     }),

--- a/app/recipes/[id]/ImageGallery.tsx
+++ b/app/recipes/[id]/ImageGallery.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+
+type ImageItem = {
+  url: string
+  isMain: boolean
+  order: number
+}
+
+type Props = {
+  images: ImageItem[]
+  alt: string
+}
+
+export default function ImageGallery({ images, alt }: Props) {
+  const mainIndex = images.findIndex((img) => img.isMain)
+  const [activeIndex, setActiveIndex] = useState(mainIndex >= 0 ? mainIndex : 0)
+  const [open, setOpen] = useState(false)
+
+  if (images.length === 0) return null
+
+  const activeImage = images[activeIndex]
+
+  return (
+    <>
+      <div className="lg:w-96 lg:flex-shrink-0 space-y-2">
+        {/* メイン画像 */}
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="relative w-full aspect-[4/3] rounded-xl overflow-hidden cursor-zoom-in block"
+        >
+          <Image
+            src={activeImage.url}
+            alt={alt}
+            fill
+            className="object-cover"
+            sizes="(max-width: 1024px) 100vw, 384px"
+            priority
+          />
+        </button>
+
+        {/* サムネイル列 */}
+        {images.length > 1 && (
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {images.map((img, index) => (
+              <button
+                key={img.url}
+                type="button"
+                onClick={() => setActiveIndex(index)}
+                className={`relative flex-shrink-0 w-14 h-14 rounded-lg overflow-hidden border-2 transition-colors ${index === activeIndex ? 'border-zinc-900' : 'border-transparent'}`}
+              >
+                <Image
+                  src={img.url}
+                  alt={`${alt} ${index + 1}`}
+                  fill
+                  className="object-cover"
+                  sizes="56px"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/80 p-4 gap-3"
+          onClick={() => setOpen(false)}
+        >
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="self-end text-white text-sm hover:text-zinc-300 transition-colors cursor-pointer"
+          >
+            閉じる ✕
+          </button>
+          <div className="relative w-full max-w-4xl flex-1 min-h-0" onClick={(e) => e.stopPropagation()}>
+            <Image
+              src={activeImage.url}
+              alt={alt}
+              fill
+              className="object-contain"
+              sizes="(max-width: 896px) 100vw, 896px"
+            />
+          </div>
+          {images.length > 1 && (
+            <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+              {images.map((img, index) => (
+                <button
+                  key={img.url}
+                  type="button"
+                  onClick={() => setActiveIndex(index)}
+                  className={`relative flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden border-2 transition-colors ${index === activeIndex ? 'border-white' : 'border-white/30'}`}
+                >
+                  <Image
+                    src={img.url}
+                    alt={`${alt} ${index + 1}`}
+                    fill
+                    className="object-cover"
+                    sizes="48px"
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/recipes/[id]/edit/EditRecipeForm.tsx
+++ b/app/recipes/[id]/edit/EditRecipeForm.tsx
@@ -47,6 +47,10 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null)
   const [uploadError, setUploadError] = useState<string | null>(null)
 
+  // Main image index (across allImages)
+  const initialMainIndex = initialValues.images.findIndex((img) => img.isMain)
+  const [mainIndex, setMainIndex] = useState(initialMainIndex >= 0 ? initialMainIndex : 0)
+
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
@@ -65,7 +69,15 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
   }
 
   const removeExistingImage = (url: string) => {
-    setExistingImages((prev) => prev.filter((img) => img.url !== url))
+    setExistingImages((prev) => {
+      const removedIndex = prev.findIndex((img) => img.url === url)
+      setMainIndex((m) => {
+        if (removedIndex < m) return m - 1
+        if (removedIndex === m) return 0
+        return m
+      })
+      return prev.filter((img) => img.url !== url)
+    })
     setDeletedImageUrls((prev) => [...prev, url])
   }
 
@@ -73,6 +85,11 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
     setImageFile(null)
     setImagePreviewUrl(null)
     setUploadError(null)
+    // If new image was main, reset to first
+    setMainIndex((m) => {
+      const newImgIndex = existingImages.length
+      return m === newImgIndex ? 0 : m
+    })
   }
 
   const addIngredient = () =>
@@ -126,14 +143,11 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
             return
           }
           const { data: { publicUrl } } = supabase.storage.from('recipe-images').getPublicUrl(path)
-          const isFirst = images.length === 0
-          images = [...images, { url: publicUrl, isMain: isFirst, order: images.length }]
+          images = [...images, { url: publicUrl, isMain: false, order: images.length }]
         }
 
-        // Ensure at least one isMain if images exist
-        if (images.length > 0 && !images.some((img) => img.isMain)) {
-          images = images.map((img, i) => ({ ...img, isMain: i === 0 }))
-        }
+        // Apply mainIndex
+        images = images.map((img, i) => ({ ...img, isMain: i === mainIndex }))
 
         await updateRecipe(recipeId, {
           title,
@@ -155,7 +169,7 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
 
   const allImages = [
     ...existingImages.map((img) => ({ ...img, isNew: false })),
-    ...(imagePreviewUrl ? [{ url: imagePreviewUrl, isMain: existingImages.length === 0, order: existingImages.length, isNew: true }] : []),
+    ...(imagePreviewUrl ? [{ url: imagePreviewUrl, isMain: false, order: existingImages.length, isNew: true }] : []),
   ]
 
   return (
@@ -194,14 +208,21 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
               <div className="flex flex-wrap gap-2">
                 {allImages.map((img, index) => (
                   <div key={img.url} className="relative">
-                    {img.isNew ? (
-                      <img src={img.url} alt="プレビュー" className="w-20 h-20 object-cover rounded-lg" />
-                    ) : (
-                      <div className="relative w-20 h-20 rounded-lg overflow-hidden">
-                        <Image src={img.url} alt="レシピ画像" fill className="object-cover" sizes="80px" />
-                      </div>
-                    )}
-                    {index === 0 && (
+                    <button
+                      type="button"
+                      aria-label={index === mainIndex ? 'メイン画像' : 'メインに設定'}
+                      onClick={() => setMainIndex(index)}
+                      className={`block w-20 h-20 rounded-lg overflow-hidden border-2 transition-colors ${index === mainIndex ? 'border-zinc-900' : 'border-transparent'}`}
+                    >
+                      {img.isNew ? (
+                        <img src={img.url} alt="プレビュー" className="w-full h-full object-cover" />
+                      ) : (
+                        <div className="relative w-full h-full">
+                          <Image src={img.url} alt="レシピ画像" fill className="object-cover" sizes="80px" />
+                        </div>
+                      )}
+                    </button>
+                    {index === mainIndex && (
                       <span className="absolute top-0 left-0 text-xs bg-zinc-900 text-white px-1 rounded-tl-lg rounded-br-lg pointer-events-none">メイン</span>
                     )}
                     <button

--- a/app/recipes/[id]/edit/EditRecipeForm.tsx
+++ b/app/recipes/[id]/edit/EditRecipeForm.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
-import { updateRecipe, type IngredientInput, type StepInput } from '../../actions'
+import { updateRecipe, type IngredientInput, type StepInput, type RecipeImageInput } from '../../actions'
 import { createClient } from '../../../utils/supabase/client'
 import { convertImage } from '../../../utils/imageConverter'
 
@@ -16,7 +16,7 @@ type InitialValues = {
   ingredients: IngredientInput[]
   steps: StepInput[]
   categories: string[]
-  imageUrl: string | null
+  images: RecipeImageInput[]
 }
 
 type Props = {
@@ -37,9 +37,14 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
   const [steps, setSteps] = useState<StepInput[]>(initialValues.steps)
   const [categoryInput, setCategoryInput] = useState('')
   const [categories, setCategories] = useState<string[]>(initialValues.categories)
+
+  // Existing images (from DB)
+  const [existingImages, setExistingImages] = useState<RecipeImageInput[]>(initialValues.images)
+  const [deletedImageUrls, setDeletedImageUrls] = useState<string[]>([])
+
+  // New image to add
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null)
-  const [existingImageUrl, setExistingImageUrl] = useState<string | null>(initialValues.imageUrl)
   const [uploadError, setUploadError] = useState<string | null>(null)
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -59,10 +64,14 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
     }
   }
 
-  const clearImage = () => {
+  const removeExistingImage = (url: string) => {
+    setExistingImages((prev) => prev.filter((img) => img.url !== url))
+    setDeletedImageUrls((prev) => [...prev, url])
+  }
+
+  const clearNewImage = () => {
     setImageFile(null)
     setImagePreviewUrl(null)
-    setExistingImageUrl(null)
     setUploadError(null)
   }
 
@@ -101,7 +110,8 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
     setError(null)
     startTransition(async () => {
       try {
-        let imageUrl: string | undefined = existingImageUrl ?? undefined
+        let images: RecipeImageInput[] = [...existingImages]
+
         if (imageFile) {
           const supabase = createClient()
           const { data: { user } } = await supabase.auth.getUser()
@@ -116,15 +126,37 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
             return
           }
           const { data: { publicUrl } } = supabase.storage.from('recipe-images').getPublicUrl(path)
-          imageUrl = publicUrl
+          const isFirst = images.length === 0
+          images = [...images, { url: publicUrl, isMain: isFirst, order: images.length }]
         }
-        await updateRecipe(recipeId, { title, description, servings, cookTime, ingredients, steps, categories, imageUrl })
+
+        // Ensure at least one isMain if images exist
+        if (images.length > 0 && !images.some((img) => img.isMain)) {
+          images = images.map((img, i) => ({ ...img, isMain: i === 0 }))
+        }
+
+        await updateRecipe(recipeId, {
+          title,
+          description,
+          servings,
+          cookTime,
+          ingredients,
+          steps,
+          categories,
+          images,
+          deletedImageUrls,
+        })
       } catch (err) {
         if (isRedirectError(err)) throw err
         setError('保存に失敗しました。もう一度お試しください。')
       }
     })
   }
+
+  const allImages = [
+    ...existingImages.map((img) => ({ ...img, isNew: false })),
+    ...(imagePreviewUrl ? [{ url: imagePreviewUrl, isMain: existingImages.length === 0, order: existingImages.length, isNew: true }] : []),
+  ]
 
   return (
     <div className="min-h-screen bg-zinc-50">
@@ -157,27 +189,37 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
                 {uploadError}
               </p>
             )}
-            {imagePreviewUrl ? (
-              <div className="space-y-2">
-                <div className="w-full aspect-video rounded-lg overflow-hidden bg-zinc-100">
-                  <img src={imagePreviewUrl} alt="プレビュー" className="w-full h-full object-cover" />
-                </div>
-                <button type="button" onClick={clearImage} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
-                  写真を削除
-                </button>
+
+            {allImages.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {allImages.map((img, index) => (
+                  <div key={img.url} className="relative">
+                    {img.isNew ? (
+                      <img src={img.url} alt="プレビュー" className="w-20 h-20 object-cover rounded-lg" />
+                    ) : (
+                      <div className="relative w-20 h-20 rounded-lg overflow-hidden">
+                        <Image src={img.url} alt="レシピ画像" fill className="object-cover" sizes="80px" />
+                      </div>
+                    )}
+                    {index === 0 && (
+                      <span className="absolute top-0 left-0 text-xs bg-zinc-900 text-white px-1 rounded-tl-lg rounded-br-lg pointer-events-none">メイン</span>
+                    )}
+                    <button
+                      type="button"
+                      aria-label="削除"
+                      onClick={() => img.isNew ? clearNewImage() : removeExistingImage(img.url)}
+                      className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 text-white rounded-full text-xs flex items-center justify-center leading-none"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
               </div>
-            ) : existingImageUrl ? (
-              <div className="space-y-2">
-                <div className="relative w-full aspect-video rounded-lg overflow-hidden bg-zinc-100">
-                  <Image src={existingImageUrl} alt="現在の写真" fill className="object-cover" sizes="(max-width: 672px) 100vw, 672px" />
-                </div>
-                <button type="button" onClick={clearImage} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
-                  写真を削除
-                </button>
-              </div>
-            ) : (
+            )}
+
+            {!imagePreviewUrl && (
               <label className="flex flex-col items-center justify-center w-full h-32 rounded-lg border-2 border-dashed border-zinc-300 cursor-pointer hover:border-zinc-400 transition-colors">
-                <span className="text-sm text-zinc-500">タップして写真を選択</span>
+                <span className="text-sm text-zinc-500">タップして写真を追加</span>
                 <input
                   type="file"
                   accept="image/*"

--- a/app/recipes/[id]/edit/page.test.tsx
+++ b/app/recipes/[id]/edit/page.test.tsx
@@ -46,7 +46,7 @@ const defaultInitialValues = {
   ingredients: [{ name: 'じゃがいも', amount: '2', unit: '個' }],
   steps: [{ description: '具材を炒める' }],
   categories: ['和食'],
-  imageUrl: null as string | null,
+  images: [] as Array<{ url: string; isMain: boolean; order: number }>,
 }
 
 describe('EditRecipeForm', () => {
@@ -65,15 +65,18 @@ describe('EditRecipeForm', () => {
     expect(screen.getByText('手順')).toBeInTheDocument()
   })
 
-  it('既存の imageUrl がある場合に現在の写真が表示される', () => {
+  it('既存の images がある場合に写真が表示される', () => {
     render(
       <EditRecipeForm
         recipeId="recipe-1"
-        initialValues={{ ...defaultInitialValues, imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/photo.jpg' }}
+        initialValues={{
+          ...defaultInitialValues,
+          images: [{ url: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/photo.jpg', isMain: true, order: 0 }],
+        }}
       />
     )
 
-    expect(screen.getByRole('img', { name: '現在の写真' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'レシピ画像' })).toBeInTheDocument()
   })
 
   it('新しいファイルを選択するとプレビューが表示される', async () => {
@@ -88,7 +91,7 @@ describe('EditRecipeForm', () => {
     })
   })
 
-  it('写真付きで送信すると storage.upload が呼ばれ updateRecipe に imageUrl が渡される', async () => {
+  it('写真付きで送信すると storage.upload が呼ばれ updateRecipe に images が渡される', async () => {
     const user = userEvent.setup()
     mockSupabaseUpload.mockResolvedValue({ data: { path: 'photos/user-1/uuid.jpg' }, error: null })
     mockSupabaseGetPublicUrl.mockReturnValue({ data: { publicUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg' } })
@@ -103,7 +106,9 @@ describe('EditRecipeForm', () => {
       expect(mockSupabaseUpload).toHaveBeenCalled()
       expect(mockUpdateRecipe).toHaveBeenCalledWith(
         'recipe-1',
-        expect.objectContaining({ imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg' })
+        expect.objectContaining({
+          images: [{ url: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg', isMain: true, order: 0 }],
+        })
       )
     })
   })

--- a/app/recipes/[id]/edit/page.tsx
+++ b/app/recipes/[id]/edit/page.tsx
@@ -20,6 +20,7 @@ export default async function EditRecipePage({ params }: Props) {
       ingredients: { orderBy: { order: 'asc' } },
       steps: { orderBy: { order: 'asc' } },
       categories: { include: { category: true } },
+      images: { orderBy: { order: 'asc' } },
     },
   })
 
@@ -37,7 +38,7 @@ export default async function EditRecipePage({ params }: Props) {
     })),
     steps: recipe.steps.map((step) => ({ description: step.description })),
     categories: recipe.categories.map((rc) => rc.category.name),
-    imageUrl: recipe.imageUrl,
+    images: recipe.images.map((img) => ({ url: img.url, isMain: img.isMain, order: img.order })),
   }
 
   return <EditRecipeForm recipeId={recipe.id} initialValues={initialValues} />

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import { createClient } from '../../utils/supabase/server'
 import { prisma } from '../../../lib/prisma'
 import DeleteButton from './DeleteButton'
-import ImageModal from './ImageModal'
+import ImageGallery from './ImageGallery'
 import BackButton from './BackButton'
 
 type Props = {
@@ -22,6 +22,7 @@ export default async function RecipeDetailPage({ params }: Props) {
       ingredients: { orderBy: { order: 'asc' } },
       steps: { orderBy: { order: 'asc' } },
       categories: { include: { category: true } },
+      images: { orderBy: { order: 'asc' } },
     },
   })
 
@@ -47,8 +48,8 @@ export default async function RecipeDetailPage({ params }: Props) {
 
         {/* 上段: 画像 + タイトル・説明 */}
         <div className="flex flex-col lg:flex-row gap-12">
-          {recipe.imageUrl && (
-            <ImageModal src={recipe.imageUrl} alt={recipe.title} />
+          {recipe.images.length > 0 && (
+            <ImageGallery images={recipe.images} alt={recipe.title} />
           )}
           <div className="flex-1 space-y-3">
             <h1 className="text-4xl font-bold text-zinc-900">{recipe.title}</h1>

--- a/app/recipes/actions.test.ts
+++ b/app/recipes/actions.test.ts
@@ -13,6 +13,9 @@ const {
   mockIngredientCreateMany,
   mockStepCreateMany,
   mockRecipeCategoryCreateMany,
+  mockRecipeImageDeleteMany,
+  mockRecipeImageCreateMany,
+  mockRecipeImageFindMany,
   mockTransaction,
   mockRedirect,
   mockStorageRemove,
@@ -32,6 +35,9 @@ const {
   mockIngredientCreateMany: vi.fn(),
   mockStepCreateMany: vi.fn(),
   mockRecipeCategoryCreateMany: vi.fn(),
+  mockRecipeImageDeleteMany: vi.fn(),
+  mockRecipeImageCreateMany: vi.fn(),
+  mockRecipeImageFindMany: vi.fn(),
   mockTransaction: vi.fn(),
   mockRedirect: vi.fn(),
   mockStorageRemove: vi.fn(),
@@ -60,6 +66,7 @@ vi.mock('../../lib/prisma', () => ({
     ingredient: { deleteMany: mockIngredientDeleteMany, createMany: mockIngredientCreateMany },
     step: { deleteMany: mockStepDeleteMany, createMany: mockStepCreateMany },
     recipeCategory: { deleteMany: mockRecipeCategoryDeleteMany, createMany: mockRecipeCategoryCreateMany },
+    recipeImage: { deleteMany: mockRecipeImageDeleteMany, createMany: mockRecipeImageCreateMany, findMany: mockRecipeImageFindMany },
     mealRecord: { create: mockMealRecordCreate },
     $transaction: mockTransaction,
   },
@@ -102,9 +109,7 @@ describe('createRecipe', () => {
   })
 
   it('成功時: prisma.recipe.create を呼び、/ にリダイレクトする', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
-    })
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
 
     await createRecipe(baseInput)
@@ -122,52 +127,40 @@ describe('createRecipe', () => {
   })
 
   it('servings・cookTime が数値文字列の場合: parseInt して渡す', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
-    })
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
 
     await createRecipe({ ...baseInput, servings: '4', cookTime: '30' })
 
     expect(mockRecipeCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
-          servings: 4,
-          cookTime: 30,
-        }),
+        data: expect.objectContaining({ servings: 4, cookTime: 30 }),
       })
     )
   })
 
   it('servings・cookTime が空文字の場合: null を渡す', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
-    })
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
 
     await createRecipe({ ...baseInput, servings: '', cookTime: '' })
 
     expect(mockRecipeCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
-          servings: null,
-          cookTime: null,
-        }),
+        data: expect.objectContaining({ servings: null, cookTime: null }),
       })
     )
   })
 
   it('name が空の材料はフィルタリングされる', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
-    })
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
 
     await createRecipe({
       ...baseInput,
       ingredients: [
         { name: 'じゃがいも', amount: '2', unit: '個' },
-        { name: '  ', amount: '', unit: '' }, // 空白のみ → フィルタ対象
+        { name: '  ', amount: '', unit: '' },
       ],
     })
 
@@ -177,17 +170,12 @@ describe('createRecipe', () => {
   })
 
   it('description が空の手順はフィルタリングされる', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
-    })
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
 
     await createRecipe({
       ...baseInput,
-      steps: [
-        { description: '具材を炒める' },
-        { description: '' }, // 空 → フィルタ対象
-      ],
+      steps: [{ description: '具材を炒める' }, { description: '' }],
     })
 
     const createCall = mockRecipeCreate.mock.calls[0][0]
@@ -196,9 +184,7 @@ describe('createRecipe', () => {
   })
 
   it('材料の order は配列インデックス順になる', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
-    })
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
 
     await createRecipe({
@@ -218,9 +204,7 @@ describe('createRecipe', () => {
   })
 
   it('カテゴリがある場合: prisma.category.upsert を呼ぶ', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
-    })
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockCategoryUpsert
       .mockResolvedValueOnce({ id: 'cat-1' })
       .mockResolvedValueOnce({ id: 'cat-2' })
@@ -241,25 +225,77 @@ describe('createRecipe', () => {
     ])
   })
 
-  it('外部imageUrlのfetchが失敗した場合: imageUrlがnullになる', async () => {
+  it('images なしの場合: images.create が空になる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({ ok: false } as Response)
 
-    await createRecipe({ ...baseInput, imageUrl: 'https://example.com/photo.jpg', sourceType: 'url', sourceUrl: 'https://example.com/recipe' })
+    await createRecipe(baseInput)
 
-    // fetch失敗時はimageUrlがnullになるが、sourceTypeはurlのまま
-    expect(mockRecipeCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          imageUrl: null,
-          sourceType: 'url',
-        }),
-      })
-    )
+    const createCall = mockRecipeCreate.mock.calls[0][0]
+    expect(createCall.data.images.create).toHaveLength(0)
+    expect(createCall.data).not.toHaveProperty('imageUrl')
   })
 
-  it('外部imageUrlのバケット保存が成功した場合: バケットURLとsourceType photoで保存される', async () => {
+  it('images 1枚の場合: isMain:true で1レコード作成される', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
+
+    await createRecipe({
+      ...baseInput,
+      images: [{ url: 'https://example.com/photo.jpg', isMain: true, order: 0 }],
+    })
+
+    const createCall = mockRecipeCreate.mock.calls[0][0]
+    expect(createCall.data.images.create).toHaveLength(1)
+    expect(createCall.data.images.create[0]).toEqual({
+      url: 'https://example.com/photo.jpg',
+      isMain: true,
+      order: 0,
+    })
+  })
+
+  it('images 複数枚の場合: 渡された isMain がそのまま保存される', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
+
+    await createRecipe({
+      ...baseInput,
+      images: [
+        { url: 'https://example.com/photo1.jpg', isMain: true, order: 0 },
+        { url: 'https://example.com/photo2.jpg', isMain: false, order: 1 },
+      ],
+    })
+
+    const createCall = mockRecipeCreate.mock.calls[0][0]
+    expect(createCall.data.images.create).toHaveLength(2)
+    expect(createCall.data.images.create[0].isMain).toBe(true)
+    expect(createCall.data.images.create[1].isMain).toBe(false)
+  })
+
+  it('images がある場合: sourceType が photo になる', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
+
+    await createRecipe({
+      ...baseInput,
+      images: [{ url: 'https://example.com/photo.jpg', isMain: true, order: 0 }],
+    })
+
+    const createCall = mockRecipeCreate.mock.calls[0][0]
+    expect(createCall.data.sourceType).toBe('photo')
+  })
+
+  it('images なしの場合: sourceType が manual になる', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
+
+    await createRecipe(baseInput)
+
+    const createCall = mockRecipeCreate.mock.calls[0][0]
+    expect(createCall.data.sourceType).toBe('manual')
+  })
+
+  it('外部URLの画像(sourceType:url)の場合: Storageにアップロードしてimagesに保存される', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
     vi.spyOn(global, 'fetch').mockResolvedValueOnce({
@@ -271,40 +307,43 @@ describe('createRecipe', () => {
       data: { publicUrl: 'https://project.supabase.co/storage/v1/object/public/recipe-images/url-imports/user-1/uuid.jpg' },
     })
 
-    await createRecipe({ ...baseInput, imageUrl: 'https://example.com/photo.jpg' })
+    await createRecipe({
+      ...baseInput,
+      images: [{ url: 'https://example.com/photo.jpg', isMain: true, order: 0 }],
+      sourceType: 'url',
+      sourceUrl: 'https://example.com/recipe',
+    })
 
     expect(mockStorageUpload).toHaveBeenCalledWith(
       expect.stringMatching(/^url-imports\/user-1\/.+\.jpg$/),
       expect.anything(),
       expect.anything()
     )
-    expect(mockRecipeCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          imageUrl: 'https://project.supabase.co/storage/v1/object/public/recipe-images/url-imports/user-1/uuid.jpg',
-          sourceType: 'photo',
-        }),
-      })
+    const createCall = mockRecipeCreate.mock.calls[0][0]
+    expect(createCall.data.images.create[0].url).toBe(
+      'https://project.supabase.co/storage/v1/object/public/recipe-images/url-imports/user-1/uuid.jpg'
     )
+    expect(createCall.data.sourceType).toBe('url')
   })
 
-  it('imageUrl が未指定の場合: sourceType が manual、imageUrl が null になる', async () => {
+  it('外部URLのfetchが失敗した場合: imagesは空になる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({ ok: false } as Response)
 
-    await createRecipe(baseInput)
+    await createRecipe({
+      ...baseInput,
+      images: [{ url: 'https://example.com/photo.jpg', isMain: true, order: 0 }],
+      sourceType: 'url',
+      sourceUrl: 'https://example.com/recipe',
+    })
 
-    expect(mockRecipeCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          imageUrl: null,
-          sourceType: 'manual',
-        }),
-      })
-    )
+    const createCall = mockRecipeCreate.mock.calls[0][0]
+    expect(createCall.data.images.create).toHaveLength(0)
+    expect(createCall.data.sourceType).toBe('url')
   })
 
-  it('sourceType が url の場合: sourceType が url、sourceUrl が渡される', async () => {
+  it('sourceType が url の場合: sourceUrl が渡される', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
 
@@ -321,15 +360,12 @@ describe('createRecipe', () => {
   })
 
   it('空文字カテゴリはスキップする', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'user-1' } },
-    })
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockCategoryUpsert.mockResolvedValue({ id: 'cat-1' })
     mockRecipeCreate.mockResolvedValue({ id: 'recipe-abc' })
 
     await createRecipe({ ...baseInput, categories: ['和食', '  ', ''] })
 
-    // '  ' と '' はスキップされるので upsert は1回のみ
     expect(mockCategoryUpsert).toHaveBeenCalledTimes(1)
     expect(mockCategoryUpsert).toHaveBeenCalledWith(
       expect.objectContaining({ where: { name: '和食' } })
@@ -393,10 +429,12 @@ describe('updateRecipe', () => {
     mockIngredientDeleteMany.mockResolvedValue({})
     mockStepDeleteMany.mockResolvedValue({})
     mockRecipeCategoryDeleteMany.mockResolvedValue({})
+    mockRecipeImageDeleteMany.mockResolvedValue({})
     mockRecipeUpdate.mockResolvedValue({ id: 'recipe-1' })
     mockIngredientCreateMany.mockResolvedValue({})
     mockStepCreateMany.mockResolvedValue({})
     mockRecipeCategoryCreateMany.mockResolvedValue({})
+    mockRecipeImageCreateMany.mockResolvedValue({})
   })
 
   it('未認証の場合: /login にリダイレクトし $transaction を呼ばない', async () => {
@@ -493,23 +531,38 @@ describe('updateRecipe', () => {
     expect(createCall.data).toHaveLength(1)
   })
 
-  it('imageUrl が渡された場合: sourceType が photo になる', async () => {
+  it('images がある場合: recipeImage.deleteMany → createMany が呼ばれる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
 
-    await updateRecipe('recipe-1', { ...baseInput, imageUrl: 'https://example.com/photo.jpg' })
+    await updateRecipe('recipe-1', {
+      ...baseInput,
+      images: [{ url: 'https://example.com/photo.jpg', isMain: true, order: 0 }],
+    })
+
+    expect(mockRecipeImageDeleteMany).toHaveBeenCalledWith({ where: { recipeId: 'recipe-1' } })
+    expect(mockRecipeImageCreateMany).toHaveBeenCalledWith({
+      data: [{ recipeId: 'recipe-1', url: 'https://example.com/photo.jpg', isMain: true, order: 0 }],
+    })
+  })
+
+  it('images がある場合: sourceType が photo になる', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+
+    await updateRecipe('recipe-1', {
+      ...baseInput,
+      images: [{ url: 'https://example.com/photo.jpg', isMain: true, order: 0 }],
+    })
 
     expect(mockRecipeUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
-          imageUrl: 'https://example.com/photo.jpg',
-          sourceType: 'photo',
-        }),
+        data: expect.objectContaining({ sourceType: 'photo' }),
       })
     )
   })
 
-  it('imageUrl が未指定の場合: sourceType が manual、imageUrl が null になる', async () => {
+  it('images なしの場合: sourceType が manual になる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
     mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
 
@@ -517,12 +570,24 @@ describe('updateRecipe', () => {
 
     expect(mockRecipeUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({
-          imageUrl: null,
-          sourceType: 'manual',
-        }),
+        data: expect.objectContaining({ sourceType: 'manual' }),
       })
     )
+  })
+
+  it('deletedImageUrls がある場合: Storage から削除する', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockStorageRemove.mockResolvedValue({ error: null })
+
+    await updateRecipe('recipe-1', {
+      ...baseInput,
+      deletedImageUrls: [
+        'https://project.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg',
+      ],
+    })
+
+    expect(mockStorageRemove).toHaveBeenCalledWith(['photos/user-1/uuid.jpg'])
   })
 
   it('カテゴリがある場合: prisma.category.upsert を呼ぶ', async () => {
@@ -570,37 +635,39 @@ describe('deleteRecipe', () => {
 
   it('自分のレシピの場合: prisma.recipe.delete を呼び / にリダイレクトする', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
-    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1', imageUrl: null })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockRecipeImageFindMany.mockResolvedValue([])
     mockRecipeDelete.mockResolvedValue({})
 
     await deleteRecipe('recipe-1')
 
-    expect(mockRecipeFindFirst).toHaveBeenCalledWith({
-      where: { id: 'recipe-1', userId: 'user-1' },
-    })
     expect(mockRecipeDelete).toHaveBeenCalledWith({ where: { id: 'recipe-1' } })
     expect(mockRedirect).toHaveBeenCalledWith('/')
   })
 
-  it('imageUrl がある場合: Storage からファイルを削除する', async () => {
+  it('RecipeImage がある場合: 全URLをStorageから削除する', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
-    mockRecipeFindFirst.mockResolvedValue({
-      id: 'recipe-1',
-      userId: 'user-1',
-      imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/user-1/uuid.jpg',
-    })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockRecipeImageFindMany.mockResolvedValue([
+      { url: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/img1.jpg' },
+      { url: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/img2.jpg' },
+    ])
     mockRecipeDelete.mockResolvedValue({})
     mockStorageRemove.mockResolvedValue({ error: null })
 
     await deleteRecipe('recipe-1')
 
-    expect(mockStorageRemove).toHaveBeenCalledWith(['user-1/uuid.jpg'])
+    expect(mockStorageRemove).toHaveBeenCalledWith([
+      'photos/user-1/img1.jpg',
+      'photos/user-1/img2.jpg',
+    ])
     expect(mockRecipeDelete).toHaveBeenCalledWith({ where: { id: 'recipe-1' } })
   })
 
-  it('imageUrl がない場合: Storage の削除は呼ばない', async () => {
+  it('RecipeImage がない場合: Storageの削除は呼ばない', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
-    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1', imageUrl: null })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockRecipeImageFindMany.mockResolvedValue([])
     mockRecipeDelete.mockResolvedValue({})
 
     await deleteRecipe('recipe-1')
@@ -610,17 +677,15 @@ describe('deleteRecipe', () => {
 
   it('url-imports パスの画像がある場合: バケットから正しいパスで削除する', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
-    mockRecipeFindFirst.mockResolvedValue({
-      id: 'recipe-1',
-      userId: 'user-1',
-      imageUrl: 'https://project.supabase.co/storage/v1/object/public/recipe-images/url-imports/user-1/uuid.jpg',
-    })
+    mockRecipeFindFirst.mockResolvedValue({ id: 'recipe-1', userId: 'user-1' })
+    mockRecipeImageFindMany.mockResolvedValue([
+      { url: 'https://project.supabase.co/storage/v1/object/public/recipe-images/url-imports/user-1/uuid.jpg' },
+    ])
     mockRecipeDelete.mockResolvedValue({})
     mockStorageRemove.mockResolvedValue({ error: null })
 
     await deleteRecipe('recipe-1')
 
     expect(mockStorageRemove).toHaveBeenCalledWith(['url-imports/user-1/uuid.jpg'])
-    expect(mockRecipeDelete).toHaveBeenCalledWith({ where: { id: 'recipe-1' } })
   })
 })

--- a/app/recipes/actions.ts
+++ b/app/recipes/actions.ts
@@ -17,6 +17,12 @@ export type StepInput = {
   description: string
 }
 
+export type RecipeImageInput = {
+  url: string
+  isMain: boolean
+  order: number
+}
+
 export type CreateRecipeInput = {
   title: string
   description: string
@@ -25,9 +31,13 @@ export type CreateRecipeInput = {
   ingredients: IngredientInput[]
   steps: StepInput[]
   categories: string[]
-  imageUrl?: string
+  images?: RecipeImageInput[]
   sourceType?: 'url' | 'photo' | 'manual'
   sourceUrl?: string
+}
+
+export type UpdateRecipeInput = CreateRecipeInput & {
+  deletedImageUrls?: string[]
 }
 
 const calendarPattern = /^\/calendar\/(\d{4}-\d{2}-\d{2})$/
@@ -47,33 +57,36 @@ export async function createRecipe(input: CreateRecipeInput, from?: string) {
   const cookTime = input.cookTime ? parseInt(input.cookTime, 10) : null
 
   // 外部URLの画像をバケットに保存
-  let resolvedImageUrl = input.imageUrl ?? null
-  if (input.imageUrl && !input.imageUrl.includes(process.env.NEXT_PUBLIC_SUPABASE_URL!)) {
-    try {
-      const res = await fetch(input.imageUrl, { signal: AbortSignal.timeout(10000) })
-      if (res.ok) {
-        const arrayBuffer = await res.arrayBuffer()
-        const resized = await sharp(Buffer.from(arrayBuffer))
-          .resize(800, 800, { fit: 'inside', withoutEnlargement: true })
-          .jpeg({ quality: 80 })
-          .toBuffer()
-        const filePath = `url-imports/${user.id}/${randomUUID()}.jpg`
-        const { error } = await supabase.storage
-          .from('recipe-images')
-          .upload(filePath, resized, { contentType: 'image/jpeg', upsert: false })
-        if (!error) {
-          const { data } = supabase.storage.from('recipe-images').getPublicUrl(filePath)
-          resolvedImageUrl = data.publicUrl
-        } else {
-          resolvedImageUrl = null
+  let resolvedImages: RecipeImageInput[] = input.images ?? []
+  if (input.sourceType === 'url' && resolvedImages.length > 0) {
+    const uploadedImages: RecipeImageInput[] = []
+    for (const img of resolvedImages) {
+      if (!img.url.includes(process.env.NEXT_PUBLIC_SUPABASE_URL!)) {
+        try {
+          const res = await fetch(img.url, { signal: AbortSignal.timeout(10000) })
+          if (res.ok) {
+            const arrayBuffer = await res.arrayBuffer()
+            const resized = await sharp(Buffer.from(arrayBuffer))
+              .resize(800, 800, { fit: 'inside', withoutEnlargement: true })
+              .jpeg({ quality: 80 })
+              .toBuffer()
+            const filePath = `url-imports/${user.id}/${randomUUID()}.jpg`
+            const { error } = await supabase.storage
+              .from('recipe-images')
+              .upload(filePath, resized, { contentType: 'image/jpeg', upsert: false })
+            if (!error) {
+              const { data } = supabase.storage.from('recipe-images').getPublicUrl(filePath)
+              uploadedImages.push({ ...img, url: data.publicUrl })
+            }
+          }
+        } catch {
+          // 画像保存失敗時はスキップ
         }
       } else {
-        resolvedImageUrl = null
+        uploadedImages.push(img)
       }
-    } catch {
-      // 画像保存失敗時は null にする
-      resolvedImageUrl = null
     }
+    resolvedImages = uploadedImages
   }
 
   const categoryIds: string[] = []
@@ -88,6 +101,9 @@ export async function createRecipe(input: CreateRecipeInput, from?: string) {
     categoryIds.push(category.id)
   }
 
+  const hasImages = resolvedImages.length > 0
+  const sourceType = input.sourceType ?? (hasImages ? 'photo' : 'manual')
+
   const recipe = await prisma.recipe.create({
     data: {
       userId: user.id,
@@ -95,8 +111,7 @@ export async function createRecipe(input: CreateRecipeInput, from?: string) {
       description: input.description || null,
       servings,
       cookTime,
-      imageUrl: resolvedImageUrl,
-      sourceType: input.sourceType ?? (resolvedImageUrl ? 'photo' : 'manual'),
+      sourceType,
       sourceUrl: input.sourceUrl ?? null,
       ingredients: {
         create: input.ingredients
@@ -119,6 +134,13 @@ export async function createRecipe(input: CreateRecipeInput, from?: string) {
       categories: {
         create: categoryIds.map((categoryId) => ({ categoryId })),
       },
+      images: {
+        create: resolvedImages.map((img) => ({
+          url: img.url,
+          isMain: img.isMain,
+          order: img.order,
+        })),
+      },
     },
   })
 
@@ -139,8 +161,6 @@ export async function createRecipe(input: CreateRecipeInput, from?: string) {
 
   redirect('/')
 }
-
-export type UpdateRecipeInput = CreateRecipeInput
 
 export async function updateRecipe(recipeId: string, input: UpdateRecipeInput) {
   const supabase = await createClient()
@@ -195,10 +215,14 @@ export async function updateRecipe(recipeId: string, input: UpdateRecipeInput) {
       order: index,
     }))
 
+  const hasImages = (input.images ?? []).length > 0
+  const sourceType = hasImages ? 'photo' : 'manual'
+
   await prisma.$transaction([
     prisma.ingredient.deleteMany({ where: { recipeId } }),
     prisma.step.deleteMany({ where: { recipeId } }),
     prisma.recipeCategory.deleteMany({ where: { recipeId } }),
+    prisma.recipeImage.deleteMany({ where: { recipeId } }),
     prisma.recipe.update({
       where: { id: recipeId },
       data: {
@@ -206,8 +230,7 @@ export async function updateRecipe(recipeId: string, input: UpdateRecipeInput) {
         description: input.description || null,
         servings,
         cookTime,
-        imageUrl: input.imageUrl ?? null,
-        sourceType: input.imageUrl ? 'photo' : 'manual',
+        sourceType,
       },
     }),
     prisma.ingredient.createMany({ data: filteredIngredients }),
@@ -215,7 +238,31 @@ export async function updateRecipe(recipeId: string, input: UpdateRecipeInput) {
     prisma.recipeCategory.createMany({
       data: categoryIds.map((categoryId) => ({ recipeId, categoryId })),
     }),
+    prisma.recipeImage.createMany({
+      data: (input.images ?? []).map((img) => ({
+        recipeId,
+        url: img.url,
+        isMain: img.isMain,
+        order: img.order,
+      })),
+    }),
   ])
+
+  // deletedImageUrls の Storage 削除
+  if (input.deletedImageUrls && input.deletedImageUrls.length > 0) {
+    const paths = input.deletedImageUrls.flatMap((url) => {
+      try {
+        const parsed = new URL(url)
+        const parts = parsed.pathname.split('/storage/v1/object/public/recipe-images/')
+        return parts[1] ? [parts[1]] : []
+      } catch {
+        return []
+      }
+    })
+    if (paths.length > 0) {
+      await supabase.storage.from('recipe-images').remove(paths)
+    }
+  }
 
   redirect(`/recipes/${recipeId}`)
 }
@@ -240,11 +287,23 @@ export async function deleteRecipe(recipeId: string) {
     return
   }
 
-  if (recipe.imageUrl) {
-    const url = new URL(recipe.imageUrl)
-    const pathParts = url.pathname.split('/storage/v1/object/public/recipe-images/')
-    if (pathParts[1]) {
-      await supabase.storage.from('recipe-images').remove([pathParts[1]])
+  const images = await prisma.recipeImage.findMany({
+    where: { recipeId },
+    select: { url: true },
+  })
+
+  if (images.length > 0) {
+    const paths = images.flatMap(({ url }) => {
+      try {
+        const parsed = new URL(url)
+        const parts = parsed.pathname.split('/storage/v1/object/public/recipe-images/')
+        return parts[1] ? [parts[1]] : []
+      } catch {
+        return []
+      }
+    })
+    if (paths.length > 0) {
+      await supabase.storage.from('recipe-images').remove(paths)
     }
   }
 

--- a/app/recipes/new/from-photo/page.test.tsx
+++ b/app/recipes/new/from-photo/page.test.tsx
@@ -81,8 +81,8 @@ const validRecipe: ParsedRecipe = {
 }
 
 // Helper: upload a file and confirm the crop
-async function uploadAndConfirmCrop(user: ReturnType<typeof userEvent.setup>, file: File) {
-  await user.upload(screen.getByLabelText('写真を選択'), file)
+async function uploadAndConfirmCrop(user: ReturnType<typeof userEvent.setup>, file: File, inputLabel = '写真を選択') {
+  await user.upload(screen.getByLabelText(inputLabel), file)
   await waitFor(() => expect(screen.getByText('この範囲で決定')).toBeInTheDocument())
   await user.click(screen.getByText('この範囲で決定'))
 }
@@ -114,7 +114,7 @@ describe('FromPhotoPage', () => {
     })
   })
 
-  it('クロップ確定後にプレビューが表示される', async () => {
+  it('クロップ確定後にサムネイルが表示される', async () => {
     const user = userEvent.setup()
     render(<FromPhotoPage />)
 
@@ -122,16 +122,31 @@ describe('FromPhotoPage', () => {
     await uploadAndConfirmCrop(user, file)
 
     await waitFor(() => {
-      expect(screen.getByRole('img', { name: 'プレビュー' })).toBeInTheDocument()
+      expect(screen.getByText('1枚選択中')).toBeInTheDocument()
     })
   })
 
-  it('クロップ確定後に自動で parseRecipeFromImage が呼ばれ、フォームに自動入力される', async () => {
+  it('クロップ確定後は自動解析されない（「解析する」ボタンが表示される）', async () => {
     const user = userEvent.setup()
     render(<FromPhotoPage />)
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
     await uploadAndConfirmCrop(user, file)
+
+    await waitFor(() => screen.getByText('1枚選択中'))
+    expect(mockParseRecipe).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: '解析する' })).toBeInTheDocument()
+  })
+
+  it('「解析する」ボタンを押すと parseRecipeFromImages が呼ばれフォームに自動入力される', async () => {
+    const user = userEvent.setup()
+    render(<FromPhotoPage />)
+
+    const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+    await uploadAndConfirmCrop(user, file)
+    await waitFor(() => screen.getByText('1枚選択中'))
+
+    await user.click(screen.getByRole('button', { name: '解析する' }))
 
     await waitFor(() => {
       expect(mockParseRecipe).toHaveBeenCalled()
@@ -150,6 +165,8 @@ describe('FromPhotoPage', () => {
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
     await uploadAndConfirmCrop(user, file)
+    await waitFor(() => screen.getByText('1枚選択中'))
+    await user.click(screen.getByRole('button', { name: '解析する' }))
 
     await waitFor(() => {
       expect(screen.getByText('画像読み取り中・・・')).toBeInTheDocument()
@@ -165,6 +182,8 @@ describe('FromPhotoPage', () => {
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
     await uploadAndConfirmCrop(user, file)
+    await waitFor(() => screen.getByText('1枚選択中'))
+    await user.click(screen.getByRole('button', { name: '解析する' }))
 
     await waitFor(() => {
       expect(screen.getByText(/解析に失敗しました/)).toBeInTheDocument()
@@ -188,6 +207,8 @@ describe('FromPhotoPage', () => {
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
     await uploadAndConfirmCrop(user, file)
+    await waitFor(() => screen.getByText('1枚選択中'))
+    await user.click(screen.getByRole('button', { name: '解析する' }))
 
     await waitFor(() => expect(mockParseRecipe).toHaveBeenCalled())
     expect(screen.getByDisplayValue('手動タイトル')).toBeInTheDocument()
@@ -199,6 +220,8 @@ describe('FromPhotoPage', () => {
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
     await uploadAndConfirmCrop(user, file)
+    await waitFor(() => screen.getByText('1枚選択中'))
+    await user.click(screen.getByRole('button', { name: '解析する' }))
 
     await waitFor(() => screen.getByDisplayValue('カレーライス'))
     const titleInput = screen.getByDisplayValue('カレーライス')
@@ -216,6 +239,8 @@ describe('FromPhotoPage', () => {
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
     await uploadAndConfirmCrop(user, file)
+    await waitFor(() => screen.getByText('1枚選択中'))
+    await user.click(screen.getByRole('button', { name: '解析する' }))
     await waitFor(() => screen.getByDisplayValue('カレーライス'))
     await user.click(screen.getByRole('button', { name: 'レシピを保存' }))
 
@@ -235,6 +260,8 @@ describe('FromPhotoPage', () => {
 
     const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
     await uploadAndConfirmCrop(user, file)
+    await waitFor(() => screen.getByText('1枚選択中'))
+    await user.click(screen.getByRole('button', { name: '解析する' }))
     await waitFor(() => screen.getByDisplayValue('カレーライス'))
     await user.click(screen.getByRole('button', { name: 'レシピを保存' }))
 
@@ -247,7 +274,7 @@ describe('FromPhotoPage', () => {
   })
 
   describe('複数画像', () => {
-    it('2枚選択するとクロップUIが表示されず、サムネイルが表示される', async () => {
+    it('アルバムから2枚選択するとクロップUIが表示されず、サムネイルが表示される', async () => {
       const user = userEvent.setup()
       const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
       const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
@@ -265,7 +292,7 @@ describe('FromPhotoPage', () => {
       })
     })
 
-    it('2枚選択すると parseRecipeFromImages が全ファイルで呼ばれる', async () => {
+    it('アルバムから2枚選択すると自動で parseRecipeFromImages が呼ばれる', async () => {
       const user = userEvent.setup()
       const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
       const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
@@ -279,6 +306,42 @@ describe('FromPhotoPage', () => {
 
       await waitFor(() => {
         expect(mockParseRecipe).toHaveBeenCalledWith([file1, file2])
+      })
+    })
+
+    it('1枚クロップ後に「写真を追加」でもクロップUIが表示される', async () => {
+      const user = userEvent.setup()
+      render(<FromPhotoPage />)
+
+      const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+      await uploadAndConfirmCrop(user, file1)
+      await waitFor(() => screen.getByText('1枚選択中'))
+
+      const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+      await user.upload(screen.getByLabelText('写真を追加'), file2)
+
+      await waitFor(() => {
+        expect(screen.getByText('この範囲で決定')).toBeInTheDocument()
+      })
+    })
+
+    it('2枚クロップ確定後に「解析する」を押すと全枚で parseRecipeFromImages が1回呼ばれる', async () => {
+      const user = userEvent.setup()
+      render(<FromPhotoPage />)
+
+      const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+      await uploadAndConfirmCrop(user, file1)
+      await waitFor(() => screen.getByText('1枚選択中'))
+
+      const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+      await uploadAndConfirmCrop(user, file2, '写真を追加')
+      await waitFor(() => screen.getByText('2枚選択中'))
+
+      await user.click(screen.getByRole('button', { name: '解析する' }))
+
+      await waitFor(() => {
+        expect(mockParseRecipe).toHaveBeenCalledTimes(1)
+        expect(mockParseRecipe.mock.calls[0][0]).toHaveLength(2)
       })
     })
 
@@ -347,7 +410,7 @@ describe('FromPhotoPage', () => {
       })
     })
 
-    it('複数画像パスの解析エラーがエラーメッセージを表示する', async () => {
+    it('アルバム一括選択の解析エラーがエラーメッセージを表示する', async () => {
       const user = userEvent.setup()
       mockParseRecipe.mockRejectedValue(new Error('parse failed'))
       const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
@@ -363,28 +426,6 @@ describe('FromPhotoPage', () => {
       await waitFor(() => {
         expect(screen.getByText(/解析に失敗しました/)).toBeInTheDocument()
       })
-    })
-  })
-
-  it('1枚クロップ確定後に「写真を追加」で別の写真を追加すると合計2枚になる', async () => {
-    const user = userEvent.setup()
-    const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
-    const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
-    mockPrepareImagesForUpload.mockResolvedValue([
-      { file: file2, previewUrl: 'blob:mock2' },
-    ])
-    render(<FromPhotoPage />)
-
-    // 1枚目をクロップ確定して解析完了まで待つ
-    await uploadAndConfirmCrop(user, file1)
-    await waitFor(() => screen.getByDisplayValue('カレーライス'))
-    await waitFor(() => screen.getByText('1枚選択中'))
-
-    // 「写真を追加」で2枚目を追加
-    await user.upload(screen.getByLabelText('写真を追加'), file2)
-
-    await waitFor(() => {
-      expect(screen.getByText('2枚選択中')).toBeInTheDocument()
     })
   })
 })

--- a/app/recipes/new/from-photo/page.test.tsx
+++ b/app/recipes/new/from-photo/page.test.tsx
@@ -3,16 +3,17 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ParsedRecipe } from '../../../types/recipe'
 
-const { mockParseRecipe, mockCreateRecipe, mockRouterBack, mockPrepareImageForCrop, mockSearchParamsGet } = vi.hoisted(() => ({
+const { mockParseRecipe, mockCreateRecipe, mockRouterBack, mockPrepareImageForCrop, mockPrepareImagesForUpload, mockSearchParamsGet } = vi.hoisted(() => ({
   mockParseRecipe: vi.fn(),
   mockCreateRecipe: vi.fn(),
   mockRouterBack: vi.fn(),
   mockPrepareImageForCrop: vi.fn(),
+  mockPrepareImagesForUpload: vi.fn(),
   mockSearchParamsGet: vi.fn().mockReturnValue(null),
 }))
 
 vi.mock('../../../utils/recipeParser', () => ({
-  parseRecipeFromImage: mockParseRecipe,
+  parseRecipeFromImages: mockParseRecipe,
 }))
 
 vi.mock('../../actions', () => ({
@@ -26,6 +27,7 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('../../../utils/imageConverter', () => ({
   prepareImageForCrop: mockPrepareImageForCrop,
+  prepareImagesForUpload: mockPrepareImagesForUpload,
 }))
 
 vi.mock('../../../utils/supabase/client', () => ({
@@ -89,6 +91,9 @@ describe('FromPhotoPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockPrepareImageForCrop.mockResolvedValue('blob:mock')
+    mockPrepareImagesForUpload.mockResolvedValue([
+      { file: new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' }), previewUrl: 'blob:mock' },
+    ])
     mockParseRecipe.mockResolvedValue(validRecipe)
   })
 
@@ -238,6 +243,126 @@ describe('FromPhotoPage', () => {
         expect.objectContaining({ title: 'カレーライス' }),
         undefined
       )
+    })
+  })
+
+  describe('複数画像', () => {
+    it('2枚選択するとクロップUIが表示されず、サムネイルが表示される', async () => {
+      const user = userEvent.setup()
+      const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+      const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+      mockPrepareImagesForUpload.mockResolvedValue([
+        { file: file1, previewUrl: 'blob:mock1' },
+        { file: file2, previewUrl: 'blob:mock2' },
+      ])
+      render(<FromPhotoPage />)
+
+      await user.upload(screen.getByLabelText('写真を選択'), [file1, file2])
+
+      await waitFor(() => {
+        expect(screen.queryByText('この範囲で決定')).not.toBeInTheDocument()
+        expect(screen.getByText('2枚選択中')).toBeInTheDocument()
+      })
+    })
+
+    it('2枚選択すると parseRecipeFromImages が全ファイルで呼ばれる', async () => {
+      const user = userEvent.setup()
+      const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+      const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+      mockPrepareImagesForUpload.mockResolvedValue([
+        { file: file1, previewUrl: 'blob:mock1' },
+        { file: file2, previewUrl: 'blob:mock2' },
+      ])
+      render(<FromPhotoPage />)
+
+      await user.upload(screen.getByLabelText('写真を選択'), [file1, file2])
+
+      await waitFor(() => {
+        expect(mockParseRecipe).toHaveBeenCalledWith([file1, file2])
+      })
+    })
+
+    it('1枚選択は引き続きクロップUIが表示される（回帰）', async () => {
+      const user = userEvent.setup()
+      render(<FromPhotoPage />)
+
+      const file = new File(['dummy'], 'recipe.jpg', { type: 'image/jpeg' })
+      await user.upload(screen.getByLabelText('写真を選択'), file)
+
+      await waitFor(() => {
+        expect(screen.getByText('この範囲で決定')).toBeInTheDocument()
+      })
+    })
+
+    it('サムネイルの×ボタンで画像を削除できる', async () => {
+      const user = userEvent.setup()
+      const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+      const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+      mockPrepareImagesForUpload.mockResolvedValue([
+        { file: file1, previewUrl: 'blob:mock1' },
+        { file: file2, previewUrl: 'blob:mock2' },
+      ])
+      render(<FromPhotoPage />)
+
+      await user.upload(screen.getByLabelText('写真を選択'), [file1, file2])
+      await waitFor(() => screen.getByText('2枚選択中'))
+
+      const removeButtons = screen.getAllByRole('button', { name: '削除' })
+      await user.click(removeButtons[1])
+
+      await waitFor(() => {
+        expect(screen.getByText('1枚選択中')).toBeInTheDocument()
+      })
+    })
+
+    it('6枚選択するとエラーメッセージが表示され、parseRecipeFromImages は呼ばれない', async () => {
+      const user = userEvent.setup()
+      render(<FromPhotoPage />)
+
+      const files = Array.from({ length: 6 }, (_, i) =>
+        new File(['a'], `photo${i}.jpg`, { type: 'image/jpeg' })
+      )
+      await user.upload(screen.getByLabelText('写真を選択'), files)
+
+      await waitFor(() => {
+        expect(screen.getByText(/5枚以下/)).toBeInTheDocument()
+      })
+      expect(mockParseRecipe).not.toHaveBeenCalled()
+    })
+
+    it('5枚選択は許可される', async () => {
+      const user = userEvent.setup()
+      const files = Array.from({ length: 5 }, (_, i) =>
+        new File(['a'], `photo${i}.jpg`, { type: 'image/jpeg' })
+      )
+      mockPrepareImagesForUpload.mockResolvedValue(
+        files.map((f, i) => ({ file: f, previewUrl: `blob:mock${i}` }))
+      )
+      render(<FromPhotoPage />)
+
+      await user.upload(screen.getByLabelText('写真を選択'), files)
+
+      await waitFor(() => {
+        expect(screen.getByText('5枚選択中')).toBeInTheDocument()
+      })
+    })
+
+    it('複数画像パスの解析エラーがエラーメッセージを表示する', async () => {
+      const user = userEvent.setup()
+      mockParseRecipe.mockRejectedValue(new Error('parse failed'))
+      const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+      const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+      mockPrepareImagesForUpload.mockResolvedValue([
+        { file: file1, previewUrl: 'blob:mock1' },
+        { file: file2, previewUrl: 'blob:mock2' },
+      ])
+      render(<FromPhotoPage />)
+
+      await user.upload(screen.getByLabelText('写真を選択'), [file1, file2])
+
+      await waitFor(() => {
+        expect(screen.getByText(/解析に失敗しました/)).toBeInTheDocument()
+      })
     })
   })
 })

--- a/app/recipes/new/from-photo/page.test.tsx
+++ b/app/recipes/new/from-photo/page.test.tsx
@@ -365,4 +365,26 @@ describe('FromPhotoPage', () => {
       })
     })
   })
+
+  it('1枚クロップ確定後に「写真を追加」で別の写真を追加すると合計2枚になる', async () => {
+    const user = userEvent.setup()
+    const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+    const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+    mockPrepareImagesForUpload.mockResolvedValue([
+      { file: file2, previewUrl: 'blob:mock2' },
+    ])
+    render(<FromPhotoPage />)
+
+    // 1枚目をクロップ確定して解析完了まで待つ
+    await uploadAndConfirmCrop(user, file1)
+    await waitFor(() => screen.getByDisplayValue('カレーライス'))
+    await waitFor(() => screen.getByText('1枚選択中'))
+
+    // 「写真を追加」で2枚目を追加
+    await user.upload(screen.getByLabelText('写真を追加'), file2)
+
+    await waitFor(() => {
+      expect(screen.getByText('2枚選択中')).toBeInTheDocument()
+    })
+  })
 })

--- a/app/recipes/new/from-photo/page.tsx
+++ b/app/recipes/new/from-photo/page.tsx
@@ -121,7 +121,17 @@ function FromPhotoPageInner() {
     }
     setUploadError(null)
     setParseError(null)
-    await mergeAndParseImages(files)
+    // Always go through crop flow when adding one at a time
+    setIsConverting(true)
+    try {
+      const url = await prepareImageForCrop(files[0])
+      setCropSrc(url)
+      setCrop(undefined)
+    } catch {
+      setUploadError('画像の変換に失敗しました。もう一度お試しください。')
+    } finally {
+      setIsConverting(false)
+    }
   }
 
   const mergeAndParseImages = async (files: File[]) => {
@@ -151,6 +161,25 @@ function FromPhotoPageInner() {
     }
   }
 
+  const handleParse = async () => {
+    if (imageItems.length === 0) return
+    setParseError(null)
+    setIsParsing(true)
+    try {
+      const parsed = await parseRecipeFromImages(imageItems.map((i) => i.file))
+      if (parsed.title !== null) setTitle(parsed.title)
+      if (parsed.description !== null) setDescription(parsed.description)
+      if (parsed.servings !== null) setServings(String(parsed.servings))
+      if (parsed.cookTime !== null) setCookTime(String(parsed.cookTime))
+      if (parsed.ingredients.length > 0) setIngredients(parsed.ingredients)
+      if (parsed.steps.length > 0) setSteps(parsed.steps.map((s) => ({ description: s })))
+    } catch {
+      setParseError('解析に失敗しました。もう一度お試しください。')
+    } finally {
+      setIsParsing(false)
+    }
+  }
+
   const onImageLoad = useCallback((e: React.SyntheticEvent<HTMLImageElement>) => {
     const { width, height } = e.currentTarget
     const initialCrop = centerCrop(
@@ -163,25 +192,14 @@ function FromPhotoPageInner() {
 
   const handleCropConfirm = async () => {
     if (!imgRef.current || !cropSrc) return
-    // If no crop selected, use full image
     const activeCrop: Crop = crop ?? { unit: '%', x: 0, y: 0, width: 100, height: 100 }
-    setIsParsing(true)
     setCropSrc(null)
     try {
       const file = await cropAndConvert(imgRef.current, activeCrop)
       const previewUrl = URL.createObjectURL(file)
       setImageItems((prev) => [...prev, { file, previewUrl }].slice(0, 5))
-      const parsed = await parseRecipeFromImages([file])
-      if (parsed.title !== null) setTitle(parsed.title)
-      if (parsed.description !== null) setDescription(parsed.description)
-      if (parsed.servings !== null) setServings(String(parsed.servings))
-      if (parsed.cookTime !== null) setCookTime(String(parsed.cookTime))
-      if (parsed.ingredients.length > 0) setIngredients(parsed.ingredients)
-      if (parsed.steps.length > 0) setSteps(parsed.steps.map((s) => ({ description: s })))
     } catch {
-      setParseError('解析に失敗しました。もう一度お試しください。')
-    } finally {
-      setIsParsing(false)
+      setUploadError('画像の変換に失敗しました。もう一度お試しください。')
     }
   }
 
@@ -366,7 +384,7 @@ function FromPhotoPageInner() {
                     </div>
                   ))}
                 </div>
-                {isParsing && (
+                {isParsing ? (
                   <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
                     <svg className="animate-spin h-4 w-4 text-zinc-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
@@ -374,30 +392,39 @@ function FromPhotoPageInner() {
                     </svg>
                     画像読み取り中・・・
                   </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleParse}
+                    className="w-full py-2.5 rounded-lg bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 transition-colors"
+                  >
+                    解析する
+                  </button>
                 )}
                 {parseError && (
                   <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
                     {parseError}
                   </p>
                 )}
-                <label className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-900 transition-colors cursor-pointer">
-                  写真を追加
-                  <input
-                    type="file"
-                    accept="image/*"
-                    multiple
-                    aria-label="写真を追加"
-                    className="sr-only"
-                    onChange={handleAddImages}
-                  />
-                </label>
-                <button
-                  type="button"
-                  onClick={clearImage}
-                  className="block text-sm text-zinc-500 hover:text-zinc-900 transition-colors"
-                >
-                  写真を削除
-                </button>
+                <div className="flex gap-3">
+                  <label className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-900 transition-colors cursor-pointer">
+                    写真を追加
+                    <input
+                      type="file"
+                      accept="image/*"
+                      aria-label="写真を追加"
+                      className="sr-only"
+                      onChange={handleAddImages}
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={clearImage}
+                    className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors"
+                  >
+                    写真を削除
+                  </button>
+                </div>
               </div>
             )}
 

--- a/app/recipes/new/from-photo/page.tsx
+++ b/app/recipes/new/from-photo/page.tsx
@@ -108,30 +108,46 @@ function FromPhotoPageInner() {
         setIsConverting(false)
       }
     } else {
-      // Multiple images: skip crop, prepare all and parse
-      setIsConverting(true)
+      await mergeAndParseImages(files)
+    }
+  }
+
+  const handleAddImages = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    if (files.length === 0) return
+    if (files.some((f) => f.size > 10 * 1024 * 1024)) {
+      setUploadError('ファイルサイズは10MB以下にしてください。')
+      return
+    }
+    setUploadError(null)
+    setParseError(null)
+    await mergeAndParseImages(files)
+  }
+
+  const mergeAndParseImages = async (files: File[]) => {
+    setIsConverting(true)
+    try {
+      const newItems = await prepareImagesForUpload(files)
+      setImageItems((prev) => [...prev, ...newItems].slice(0, 5))
+      const allFiles = [...imageItems, ...newItems].slice(0, 5).map((i) => i.file)
+      setIsParsing(true)
       try {
-        const items = await prepareImagesForUpload(files)
-        setImageItems(items)
-        setIsParsing(true)
-        try {
-          const parsed = await parseRecipeFromImages(items.map((i) => i.file))
-          if (parsed.title !== null) setTitle(parsed.title)
-          if (parsed.description !== null) setDescription(parsed.description)
-          if (parsed.servings !== null) setServings(String(parsed.servings))
-          if (parsed.cookTime !== null) setCookTime(String(parsed.cookTime))
-          if (parsed.ingredients.length > 0) setIngredients(parsed.ingredients)
-          if (parsed.steps.length > 0) setSteps(parsed.steps.map((s) => ({ description: s })))
-        } catch {
-          setParseError('解析に失敗しました。もう一度お試しください。')
-        } finally {
-          setIsParsing(false)
-        }
+        const parsed = await parseRecipeFromImages(allFiles)
+        if (parsed.title !== null) setTitle(parsed.title)
+        if (parsed.description !== null) setDescription(parsed.description)
+        if (parsed.servings !== null) setServings(String(parsed.servings))
+        if (parsed.cookTime !== null) setCookTime(String(parsed.cookTime))
+        if (parsed.ingredients.length > 0) setIngredients(parsed.ingredients)
+        if (parsed.steps.length > 0) setSteps(parsed.steps.map((s) => ({ description: s })))
       } catch {
-        setUploadError('画像の変換に失敗しました。もう一度お試しください。')
+        setParseError('解析に失敗しました。もう一度お試しください。')
       } finally {
-        setIsConverting(false)
+        setIsParsing(false)
       }
+    } catch {
+      setUploadError('画像の変換に失敗しました。もう一度お試しください。')
+    } finally {
+      setIsConverting(false)
     }
   }
 
@@ -154,7 +170,7 @@ function FromPhotoPageInner() {
     try {
       const file = await cropAndConvert(imgRef.current, activeCrop)
       const previewUrl = URL.createObjectURL(file)
-      setImageItems([{ file, previewUrl }])
+      setImageItems((prev) => [...prev, { file, previewUrl }].slice(0, 5))
       const parsed = await parseRecipeFromImages([file])
       if (parsed.title !== null) setTitle(parsed.title)
       if (parsed.description !== null) setDescription(parsed.description)
@@ -372,7 +388,7 @@ function FromPhotoPageInner() {
                     multiple
                     aria-label="写真を追加"
                     className="sr-only"
-                    onChange={handleImageChange}
+                    onChange={handleAddImages}
                   />
                 </label>
                 <button

--- a/app/recipes/new/from-photo/page.tsx
+++ b/app/recipes/new/from-photo/page.tsx
@@ -7,8 +7,8 @@ import ReactCrop, { type Crop, centerCrop, makeAspectCrop } from 'react-image-cr
 import 'react-image-crop/dist/ReactCrop.css'
 import { createRecipe, type IngredientInput, type StepInput } from '../../actions'
 import { createClient } from '../../../utils/supabase/client'
-import { prepareImageForCrop } from '../../../utils/imageConverter'
-import { parseRecipeFromImage } from '../../../utils/recipeParser'
+import { prepareImageForCrop, prepareImagesForUpload } from '../../../utils/imageConverter'
+import { parseRecipeFromImages } from '../../../utils/recipeParser'
 
 async function cropAndConvert(
   imgElement: HTMLImageElement,
@@ -71,8 +71,7 @@ function FromPhotoPageInner() {
   const [steps, setSteps] = useState<StepInput[]>([{ description: '' }])
   const [categoryInput, setCategoryInput] = useState('')
   const [categories, setCategories] = useState<string[]>([])
-  const [imageFile, setImageFile] = useState<File | null>(null)
-  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null)
+  const [imageItems, setImageItems] = useState<{ file: File; previewUrl: string }[]>([])
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [isParsing, setIsParsing] = useState(false)
   const [parseError, setParseError] = useState<string | null>(null)
@@ -83,23 +82,56 @@ function FromPhotoPageInner() {
   const imgRef = useRef<HTMLImageElement>(null)
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    if (file.size > 10 * 1024 * 1024) {
+    const files = Array.from(e.target.files ?? [])
+    if (files.length === 0) return
+    if (files.length > 5) {
+      setUploadError('写真は5枚以下で選択してください。')
+      return
+    }
+    if (files.some((f) => f.size > 10 * 1024 * 1024)) {
       setUploadError('ファイルサイズは10MB以下にしてください。')
       return
     }
     setUploadError(null)
     setParseError(null)
-    setIsConverting(true)
-    try {
-      const url = await prepareImageForCrop(file)
-      setCropSrc(url)
-      setCrop(undefined)
-    } catch {
-      setUploadError('画像の変換に失敗しました。もう一度お試しください。')
-    } finally {
-      setIsConverting(false)
+
+    if (files.length === 1) {
+      // Single image: go through crop flow
+      setIsConverting(true)
+      try {
+        const url = await prepareImageForCrop(files[0])
+        setCropSrc(url)
+        setCrop(undefined)
+      } catch {
+        setUploadError('画像の変換に失敗しました。もう一度お試しください。')
+      } finally {
+        setIsConverting(false)
+      }
+    } else {
+      // Multiple images: skip crop, prepare all and parse
+      setIsConverting(true)
+      try {
+        const items = await prepareImagesForUpload(files)
+        setImageItems(items)
+        setIsParsing(true)
+        try {
+          const parsed = await parseRecipeFromImages(items.map((i) => i.file))
+          if (parsed.title !== null) setTitle(parsed.title)
+          if (parsed.description !== null) setDescription(parsed.description)
+          if (parsed.servings !== null) setServings(String(parsed.servings))
+          if (parsed.cookTime !== null) setCookTime(String(parsed.cookTime))
+          if (parsed.ingredients.length > 0) setIngredients(parsed.ingredients)
+          if (parsed.steps.length > 0) setSteps(parsed.steps.map((s) => ({ description: s })))
+        } catch {
+          setParseError('解析に失敗しました。もう一度お試しください。')
+        } finally {
+          setIsParsing(false)
+        }
+      } catch {
+        setUploadError('画像の変換に失敗しました。もう一度お試しください。')
+      } finally {
+        setIsConverting(false)
+      }
     }
   }
 
@@ -121,10 +153,9 @@ function FromPhotoPageInner() {
     setCropSrc(null)
     try {
       const file = await cropAndConvert(imgRef.current, activeCrop)
-      setImageFile(file)
       const previewUrl = URL.createObjectURL(file)
-      setImagePreviewUrl(previewUrl)
-      const parsed = await parseRecipeFromImage(file)
+      setImageItems([{ file, previewUrl }])
+      const parsed = await parseRecipeFromImages([file])
       if (parsed.title !== null) setTitle(parsed.title)
       if (parsed.description !== null) setDescription(parsed.description)
       if (parsed.servings !== null) setServings(String(parsed.servings))
@@ -139,12 +170,18 @@ function FromPhotoPageInner() {
   }
 
   const clearImage = () => {
-    setImageFile(null)
-    setImagePreviewUrl(null)
+    setImageItems([])
     setCropSrc(null)
     setCrop(undefined)
     setUploadError(null)
     setParseError(null)
+  }
+
+  const handleRemoveImage = (index: number) => {
+    setImageItems((prev) => {
+      URL.revokeObjectURL(prev[index].previewUrl)
+      return prev.filter((_, i) => i !== index)
+    })
   }
 
   const addIngredient = () =>
@@ -183,7 +220,8 @@ function FromPhotoPageInner() {
     startTransition(async () => {
       try {
         let imageUrl: string | undefined
-        if (imageFile) {
+        const mainImageFile = imageItems[0]?.file ?? null
+        if (mainImageFile) {
           const supabase = createClient()
           const { data: { user } } = await supabase.auth.getUser()
           if (!user) {
@@ -191,7 +229,7 @@ function FromPhotoPageInner() {
             return
           }
           const path = `photos/${user.id}/${crypto.randomUUID()}.jpg`
-          const { error: uploadErr } = await supabase.storage.from('recipe-images').upload(path, imageFile)
+          const { error: uploadErr } = await supabase.storage.from('recipe-images').upload(path, mainImageFile)
           if (uploadErr) {
             console.error('Storageアップロードエラー:', uploadErr)
             setUploadError(`写真のアップロードに失敗しました。(${uploadErr.message})`)
@@ -290,11 +328,27 @@ function FromPhotoPageInner() {
               </div>
             )}
 
-            {/* プレビュー（クロップ確定後） */}
-            {imagePreviewUrl && !cropSrc && (
+            {/* サムネイル一覧（画像選択済み・クロップUI非表示時） */}
+            {imageItems.length > 0 && !cropSrc && (
               <div className="space-y-3">
-                <div className="w-full aspect-video rounded-lg overflow-hidden bg-zinc-100">
-                  <img src={imagePreviewUrl} alt="プレビュー" className="w-full h-full object-cover" />
+                <p className="text-sm text-zinc-500">{imageItems.length}枚選択中</p>
+                <div className="flex flex-wrap gap-2">
+                  {imageItems.map((item, index) => (
+                    <div key={index} className="relative">
+                      <img src={item.previewUrl} alt="プレビュー" className="w-20 h-20 object-cover rounded-lg" />
+                      {index === 0 && (
+                        <span className="absolute top-0 left-0 text-xs bg-zinc-900 text-white px-1 rounded-tl-lg rounded-br-lg">メイン</span>
+                      )}
+                      <button
+                        type="button"
+                        aria-label="削除"
+                        onClick={() => handleRemoveImage(index)}
+                        className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 text-white rounded-full text-xs flex items-center justify-center leading-none"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
                 </div>
                 {isParsing && (
                   <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
@@ -310,10 +364,21 @@ function FromPhotoPageInner() {
                     {parseError}
                   </p>
                 )}
+                <label className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-900 transition-colors cursor-pointer">
+                  写真を追加
+                  <input
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    aria-label="写真を追加"
+                    className="sr-only"
+                    onChange={handleImageChange}
+                  />
+                </label>
                 <button
                   type="button"
                   onClick={clearImage}
-                  className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors"
+                  className="block text-sm text-zinc-500 hover:text-zinc-900 transition-colors"
                 >
                   写真を削除
                 </button>
@@ -321,12 +386,13 @@ function FromPhotoPageInner() {
             )}
 
             {/* ファイル選択UI */}
-            {!cropSrc && !imagePreviewUrl && !isConverting && (
+            {!cropSrc && imageItems.length === 0 && !isConverting && (
               <label className="flex flex-col items-center justify-center w-full h-32 rounded-lg border-2 border-dashed border-zinc-300 cursor-pointer hover:border-zinc-400 transition-colors">
                 <span className="text-sm text-zinc-500">タップして写真を選択</span>
                 <input
                   type="file"
                   accept="image/*"
+                  multiple
                   aria-label="写真を選択"
                   className="sr-only"
                   onChange={handleImageChange}

--- a/app/recipes/new/from-photo/page.tsx
+++ b/app/recipes/new/from-photo/page.tsx
@@ -72,6 +72,7 @@ function FromPhotoPageInner() {
   const [categoryInput, setCategoryInput] = useState('')
   const [categories, setCategories] = useState<string[]>([])
   const [imageItems, setImageItems] = useState<{ file: File; previewUrl: string }[]>([])
+  const [mainIndex, setMainIndex] = useState(0)
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [isParsing, setIsParsing] = useState(false)
   const [parseError, setParseError] = useState<string | null>(null)
@@ -214,7 +215,13 @@ function FromPhotoPageInner() {
   const handleRemoveImage = (index: number) => {
     setImageItems((prev) => {
       URL.revokeObjectURL(prev[index].previewUrl)
-      return prev.filter((_, i) => i !== index)
+      const next = prev.filter((_, i) => i !== index)
+      return next
+    })
+    setMainIndex((prev) => {
+      if (index < prev) return prev - 1
+      if (index === prev) return 0
+      return prev
     })
   }
 
@@ -253,26 +260,27 @@ function FromPhotoPageInner() {
     setError(null)
     startTransition(async () => {
       try {
-        let imageUrl: string | undefined
-        const mainImageFile = imageItems[0]?.file ?? null
-        if (mainImageFile) {
+        const images: import('../../actions').RecipeImageInput[] = []
+        if (imageItems.length > 0) {
           const supabase = createClient()
           const { data: { user } } = await supabase.auth.getUser()
           if (!user) {
             setUploadError('セッションが切れました。再ログインしてください。')
             return
           }
-          const path = `photos/${user.id}/${crypto.randomUUID()}.jpg`
-          const { error: uploadErr } = await supabase.storage.from('recipe-images').upload(path, mainImageFile)
-          if (uploadErr) {
-            console.error('Storageアップロードエラー:', uploadErr)
-            setUploadError(`写真のアップロードに失敗しました。(${uploadErr.message})`)
-            return
+          for (let i = 0; i < imageItems.length; i++) {
+            const path = `photos/${user.id}/${crypto.randomUUID()}.jpg`
+            const { error: uploadErr } = await supabase.storage.from('recipe-images').upload(path, imageItems[i].file)
+            if (uploadErr) {
+              console.error('Storageアップロードエラー:', uploadErr)
+              setUploadError(`写真のアップロードに失敗しました。(${uploadErr.message})`)
+              return
+            }
+            const { data: { publicUrl } } = supabase.storage.from('recipe-images').getPublicUrl(path)
+            images.push({ url: publicUrl, isMain: i === mainIndex, order: i })
           }
-          const { data: { publicUrl } } = supabase.storage.from('recipe-images').getPublicUrl(path)
-          imageUrl = publicUrl
         }
-        await createRecipe({ title, description, servings, cookTime, ingredients, steps, categories, imageUrl }, from)
+        await createRecipe({ title, description, servings, cookTime, ingredients, steps, categories, images }, from)
       } catch (err) {
         if (isRedirectError(err)) throw err
         console.error('保存エラー:', err)
@@ -369,9 +377,16 @@ function FromPhotoPageInner() {
                 <div className="flex flex-wrap gap-2">
                   {imageItems.map((item, index) => (
                     <div key={index} className="relative">
-                      <img src={item.previewUrl} alt="プレビュー" className="w-20 h-20 object-cover rounded-lg" />
-                      {index === 0 && (
-                        <span className="absolute top-0 left-0 text-xs bg-zinc-900 text-white px-1 rounded-tl-lg rounded-br-lg">メイン</span>
+                      <button
+                        type="button"
+                        aria-label={index === mainIndex ? 'メイン画像' : 'メインに設定'}
+                        onClick={() => setMainIndex(index)}
+                        className={`block w-20 h-20 rounded-lg overflow-hidden border-2 transition-colors ${index === mainIndex ? 'border-zinc-900' : 'border-transparent'}`}
+                      >
+                        <img src={item.previewUrl} alt="プレビュー" className="w-full h-full object-cover" />
+                      </button>
+                      {index === mainIndex && (
+                        <span className="absolute top-0 left-0 text-xs bg-zinc-900 text-white px-1 rounded-tl-lg rounded-br-lg pointer-events-none">メイン</span>
                       )}
                       <button
                         type="button"

--- a/app/recipes/new/from-url/page.tsx
+++ b/app/recipes/new/from-url/page.tsx
@@ -28,7 +28,7 @@ function FromUrlPageInner() {
   const [steps, setSteps] = useState<StepInput[]>([{ description: '' }])
   const [categoryInput, setCategoryInput] = useState('')
   const [categories, setCategories] = useState<string[]>([])
-  const [imageUrl, setImageUrl] = useState<string | null>(null)
+  const [parsedImageUrl, setParsedImageUrl] = useState<string | null>(null)
 
   const handleLoadUrl = async () => {
     if (!url.trim()) {
@@ -58,7 +58,7 @@ function FromUrlPageInner() {
         }))
       )
       if (parsed.steps.length > 0) setSteps(parsed.steps.map((s) => ({ description: s })))
-      setImageUrl(parsed.imageUrl)
+      setParsedImageUrl(parsed.imageUrl)
     } catch {
       setParseError('解析に失敗しました。もう一度お試しください。')
     } finally {
@@ -101,6 +101,9 @@ function FromUrlPageInner() {
     setError(null)
     startTransition(async () => {
       try {
+        const images = parsedImageUrl
+          ? [{ url: parsedImageUrl, isMain: true, order: 0 }]
+          : []
         await createRecipe({
           title,
           description,
@@ -109,7 +112,7 @@ function FromUrlPageInner() {
           ingredients,
           steps,
           categories,
-          imageUrl: imageUrl ?? undefined,
+          images,
           sourceType: 'url',
           sourceUrl: url,
         }, from)
@@ -187,13 +190,13 @@ function FromUrlPageInner() {
           </section>
 
           {/* 画像プレビュー */}
-          {imageUrl && (
+          {parsedImageUrl && (
             <section className="bg-white rounded-xl border border-zinc-200 p-6 space-y-2">
               <h2 className="text-base font-semibold text-zinc-900">画像</h2>
               <div className="w-full rounded-lg overflow-hidden bg-zinc-100">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  src={imageUrl}
+                  src={parsedImageUrl!}
                   alt="レシピ画像"
                   className="w-full object-cover"
                 />

--- a/app/recipes/new/page.test.tsx
+++ b/app/recipes/new/page.test.tsx
@@ -69,7 +69,7 @@ describe('NewRecipePage', () => {
     })
   })
 
-  it('写真付きで送信すると storage.upload が呼ばれ createRecipe に imageUrl が渡される', async () => {
+  it('写真付きで送信すると storage.upload が呼ばれ createRecipe に images が渡される', async () => {
     const user = userEvent.setup()
     mockSupabaseUpload.mockResolvedValue({ data: { path: 'photos/user-1/uuid.jpg' }, error: null })
     mockSupabaseGetPublicUrl.mockReturnValue({ data: { publicUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg' } })
@@ -84,7 +84,9 @@ describe('NewRecipePage', () => {
     await waitFor(() => {
       expect(mockSupabaseUpload).toHaveBeenCalled()
       expect(mockCreateRecipe).toHaveBeenCalledWith(
-        expect.objectContaining({ imageUrl: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg' }),
+        expect.objectContaining({
+          images: [{ url: 'https://example.supabase.co/storage/v1/object/public/recipe-images/photos/user-1/uuid.jpg', isMain: true, order: 0 }],
+        }),
         undefined
       )
     })

--- a/app/recipes/new/page.tsx
+++ b/app/recipes/new/page.tsx
@@ -87,7 +87,7 @@ function NewRecipePageInner() {
     setError(null)
     startTransition(async () => {
       try {
-        let imageUrl: string | undefined
+        let images: import('../actions').RecipeImageInput[] = []
         if (imageFile) {
           const supabase = createClient()
           const { data: { user } } = await supabase.auth.getUser()
@@ -103,9 +103,9 @@ function NewRecipePageInner() {
             return
           }
           const { data: { publicUrl } } = supabase.storage.from('recipe-images').getPublicUrl(path)
-          imageUrl = publicUrl
+          images = [{ url: publicUrl, isMain: true, order: 0 }]
         }
-        await createRecipe({ title, description, servings, cookTime, ingredients, steps, categories, imageUrl }, from)
+        await createRecipe({ title, description, servings, cookTime, ingredients, steps, categories, images }, from)
       } catch (err) {
         if (isRedirectError(err)) throw err
         console.error('保存エラー:', err)

--- a/app/utils/imageConverter.test.ts
+++ b/app/utils/imageConverter.test.ts
@@ -11,7 +11,7 @@ vi.stubGlobal('URL', {
   revokeObjectURL: vi.fn(),
 })
 
-import { prepareImageForCrop, convertImage } from './imageConverter'
+import { prepareImageForCrop, convertImage, prepareImagesForUpload } from './imageConverter'
 
 describe('imageConverter', () => {
   beforeEach(() => {
@@ -75,6 +75,64 @@ describe('imageConverter', () => {
 
       const file = new File(['heic-data'], 'photo.HEIC', { type: 'image/heic' })
       await expect(prepareImageForCrop(file)).rejects.toThrow('conversion failed')
+    })
+  })
+
+  describe('prepareImagesForUpload', () => {
+    it('JPEG 配列は heicTo を呼ばず、{ file, previewUrl } の配列を返す', async () => {
+      const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+      const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+
+      const result = await prepareImagesForUpload([file1, file2])
+
+      expect(mockHeicTo).not.toHaveBeenCalled()
+      expect(result).toHaveLength(2)
+      expect(result[0].file).toBe(file1)
+      expect(result[1].file).toBe(file2)
+      expect(result[0].previewUrl).toBe('blob:mock-url')
+      expect(result[1].previewUrl).toBe('blob:mock-url')
+    })
+
+    it('HEIC ファイルは変換された File と previewUrl を返す', async () => {
+      const convertedBlob = new Blob([new Uint8Array([0xff, 0xd8])], { type: 'image/jpeg' })
+      mockHeicTo.mockResolvedValue(convertedBlob)
+
+      const file = new File(['heic'], 'photo.heic', { type: 'image/heic' })
+      const result = await prepareImagesForUpload([file])
+
+      expect(mockHeicTo).toHaveBeenCalled()
+      expect(result[0].file.type).toBe('image/jpeg')
+      expect(result[0].previewUrl).toBe('blob:mock-url')
+    })
+
+    it('混在配列は HEIC のみ変換する', async () => {
+      const convertedBlob = new Blob([], { type: 'image/jpeg' })
+      mockHeicTo.mockResolvedValue(convertedBlob)
+
+      const jpeg = new File(['a'], 'photo.jpg', { type: 'image/jpeg' })
+      const heic = new File(['b'], 'photo.heic', { type: 'image/heic' })
+      const result = await prepareImagesForUpload([jpeg, heic])
+
+      expect(mockHeicTo).toHaveBeenCalledOnce()
+      expect(result[0].file).toBe(jpeg)
+      expect(result[1].file.type).toBe('image/jpeg')
+    })
+
+    it('入力順序を保持する', async () => {
+      const file1 = new File(['a'], 'a.jpg', { type: 'image/jpeg' })
+      const file2 = new File(['b'], 'b.jpg', { type: 'image/jpeg' })
+      const file3 = new File(['c'], 'c.jpg', { type: 'image/jpeg' })
+
+      const result = await prepareImagesForUpload([file1, file2, file3])
+
+      expect(result[0].file).toBe(file1)
+      expect(result[1].file).toBe(file2)
+      expect(result[2].file).toBe(file3)
+    })
+
+    it('空配列は空配列を返す', async () => {
+      const result = await prepareImagesForUpload([])
+      expect(result).toEqual([])
     })
   })
 

--- a/app/utils/imageConverter.ts
+++ b/app/utils/imageConverter.ts
@@ -15,6 +15,24 @@ export async function prepareImageForCrop(file: File): Promise<string> {
   return URL.createObjectURL(file)
 }
 
+export async function prepareImagesForUpload(
+  files: File[]
+): Promise<{ file: File; previewUrl: string }[]> {
+  return Promise.all(
+    files.map(async (f) => {
+      if (isHeic(f)) {
+        const { heicTo } = await import('heic-to')
+        const blob = await heicTo({ blob: f, type: 'image/jpeg', quality: 0.7 })
+        const baseName = f.name.replace(/\.[^.]+$/, '')
+        const file = new File([blob], `${baseName}.jpg`, { type: 'image/jpeg' })
+        const previewUrl = URL.createObjectURL(blob)
+        return { file, previewUrl }
+      }
+      return { file: f, previewUrl: URL.createObjectURL(f) }
+    })
+  )
+}
+
 export async function convertImage(file: File): Promise<{ convertedFile: File; previewUrl: string }> {
   const { heicTo } = await import('heic-to')
   const blob = await heicTo({ blob: file, type: 'image/jpeg', quality: 0.7 })

--- a/app/utils/recipeParser.test.ts
+++ b/app/utils/recipeParser.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { parseRecipeFromImages, parseRecipeFromImage } from './recipeParser'
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }))
+vi.stubGlobal('fetch', mockFetch)
+
+const mockParsedRecipe = {
+  title: 'テストレシピ',
+  description: 'テスト説明',
+  servings: 2,
+  cookTime: 30,
+  ingredients: [{ name: '材料1', amount: '100', unit: 'g' }],
+  steps: ['手順1', '手順2'],
+  imageUrl: null,
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('parseRecipeFromImages', () => {
+  it('sends POST with images[] FormData entries for each file', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => mockParsedRecipe })
+
+    const file1 = new File(['a'], 'photo1.jpg', { type: 'image/jpeg' })
+    const file2 = new File(['b'], 'photo2.jpg', { type: 'image/jpeg' })
+
+    await parseRecipeFromImages([file1, file2])
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, options] = mockFetch.mock.calls[0]
+    expect(url).toBe('/api/recipes/parse')
+    expect(options.method).toBe('POST')
+
+    const body = options.body as FormData
+    const entries = body.getAll('images[]')
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toBe(file1)
+    expect(entries[1]).toBe(file2)
+  })
+
+  it('returns ParsedRecipe on 200', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => mockParsedRecipe })
+
+    const file = new File(['a'], 'photo.jpg', { type: 'image/jpeg' })
+    const result = await parseRecipeFromImages([file])
+
+    expect(result).toEqual(mockParsedRecipe)
+  })
+
+  it('throws on non-200 response', async () => {
+    mockFetch.mockResolvedValue({ ok: false })
+
+    const file = new File(['a'], 'photo.jpg', { type: 'image/jpeg' })
+    await expect(parseRecipeFromImages([file])).rejects.toThrow('Failed to parse recipe')
+  })
+})
+
+describe('parseRecipeFromImage (wrapper)', () => {
+  it('calls parseRecipeFromImages with a single-element array', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => mockParsedRecipe })
+
+    const file = new File(['a'], 'photo.jpg', { type: 'image/jpeg' })
+    await parseRecipeFromImage(file)
+
+    const body = mockFetch.mock.calls[0][1].body as FormData
+    const entries = body.getAll('images[]')
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toBe(file)
+  })
+})

--- a/app/utils/recipeParser.ts
+++ b/app/utils/recipeParser.ts
@@ -1,8 +1,10 @@
 import type { ParsedRecipe } from '../types/recipe'
 
-export async function parseRecipeFromImage(file: File): Promise<ParsedRecipe> {
+export async function parseRecipeFromImages(files: File[]): Promise<ParsedRecipe> {
   const formData = new FormData()
-  formData.append('image', file)
+  for (const file of files) {
+    formData.append('images[]', file)
+  }
 
   const res = await fetch('/api/recipes/parse', { method: 'POST', body: formData })
 
@@ -11,4 +13,8 @@ export async function parseRecipeFromImage(file: File): Promise<ParsedRecipe> {
   }
 
   return res.json()
+}
+
+export async function parseRecipeFromImage(file: File): Promise<ParsedRecipe> {
+  return parseRecipeFromImages([file])
 }

--- a/prisma/migrations/20260322064719_add_recipe_images_table/migration.sql
+++ b/prisma/migrations/20260322064719_add_recipe_images_table/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `image_url` on the `recipes` table. All the data in the column will be lost.
+
+*/
+-- CreateTable
+CREATE TABLE "recipe_images" (
+    "id" TEXT NOT NULL,
+    "recipe_id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "is_main" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "recipe_images_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "recipe_images" ADD CONSTRAINT "recipe_images_recipe_id_fkey" FOREIGN KEY ("recipe_id") REFERENCES "recipes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- DataMigration: 既存の image_url を recipe_images に移行
+INSERT INTO "recipe_images" ("id", "recipe_id", "url", "order", "is_main", "created_at")
+SELECT gen_random_uuid(), "id", "image_url", 0, true, "created_at"
+FROM "recipes"
+WHERE "image_url" IS NOT NULL;
+
+-- AlterTable
+ALTER TABLE "recipes" DROP COLUMN "image_url";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,6 @@ model Recipe {
   description String?
   servings    Int?
   cookTime    Int?     @map("cook_time") // 分
-  imageUrl    String?  @map("image_url")
   sourceUrl   String?  @map("source_url")
   sourceType  String?  @map("source_type") // 'url' | 'photo' | 'manual'
   createdAt   DateTime @default(now()) @map("created_at")
@@ -44,8 +43,23 @@ model Recipe {
   steps       Step[]
   categories  RecipeCategory[]
   mealRecords MealRecord[]
+  images      RecipeImage[]
 
   @@map("recipes")
+}
+
+// レシピ画像
+model RecipeImage {
+  id        String   @id @default(uuid())
+  recipeId  String   @map("recipe_id")
+  url       String
+  order     Int      @default(0)
+  isMain    Boolean  @default(false) @map("is_main")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  recipe Recipe @relation(fields: [recipeId], references: [id], onDelete: Cascade)
+
+  @@map("recipe_images")
 }
 
 // 材料


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
１枚しか読み取れなかったので、最大５枚までの写真からレシピ情報を抽出できるように変更

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #63 

## やったこと
<!-- このPRで何をしたのか -->
Prisma / DB
- Recipe.imageUrl を削除、RecipeImage テーブル（id, recipe_id, url, order, is_main, created_at）を新設
- マイグレーションに既存 image_url データを recipe_images へ移行する SQL を含む

Server Actions (app/recipes/actions.ts)
- RecipeImageInput = { url, isMain, order } 型を追加
- CreateRecipeInput: imageUrl? → images?: RecipeImageInput[]
- UpdateRecipeInput: CreateRecipeInput + deletedImageUrls?: string[]
- createRecipe: 全画像を prisma.recipe.create の images.create で一括登録、外部URL画像はStorage転送後に置換
- updateRecipe: $transaction 内で recipeImage.deleteMany → createMany、deletedImageUrls はStorage削除
- deleteRecipe: recipeImage.findMany でURL収集 → Storage一括削除 → recipe.delete

読み取り側
- app/page.tsx / calendar/[date]/page.tsx: クエリを images: { where: { isMain: true }, take: 1 } に変更
- RecipeList.tsx / HomeTabs.tsx / MealDateClient.tsx: 型を images[] に変更、表示を images[0]?.url で

書き込み側
- new/page.tsx / from-url/page.tsx: アップロード後に images: [{ url, isMain: true, order: 0 }] で渡す
- from-photo/page.tsx: mainIndex 状態を追加、サムネイルタップでメイン切り替え、全画像をStorage アップロード
- EditRecipeForm.tsx: 既存画像の保持・削除・新規追加に対応、mainIndex によるメイン切り替えUI

詳細ページ
- ImageGallery.tsx を新規作成：メイン画像 + サムネイル列 + モーダル内ギャラリー
- app/recipes/[id]/page.tsx: ImageModal → ImageGallery に差し替え


## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
