### PR TITLE
スマホ用UXの改善

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -52,7 +52,7 @@ export default async function LoginPage({ searchParams }: Props) {
 
         <button
           type="submit"
-          className="mt-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 transition-colors"
+          className="mt-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 active:bg-zinc-800 transition-colors"
         >
           ログイン
         </button>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -67,7 +67,7 @@ export default async function LoginPage({ searchParams }: Props) {
       <form action={signInWithGoogle}>
         <button
           type="submit"
-          className="w-full rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 transition-colors flex items-center justify-center gap-2"
+          className="w-full rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 active:bg-zinc-100 transition-colors flex items-center justify-center gap-2"
         >
           <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
             <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/>

--- a/app/calendar/[date]/MealDateClient.tsx
+++ b/app/calendar/[date]/MealDateClient.tsx
@@ -117,7 +117,7 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
                 <li key={r.id} data-testid={`registered-${r.recipeId}`} className="relative group">
                   <Link
                     href={`/recipes/${r.recipeId}`}
-                    className="flex flex-col bg-white rounded-xl border border-zinc-200 hover:border-zinc-400 transition-colors overflow-hidden h-full"
+                    className="flex flex-col bg-white rounded-xl border border-zinc-200 hover:border-zinc-400 active:bg-zinc-50 transition-colors overflow-hidden h-full"
                   >
                     {recipe?.images[0]?.url ? (
                       <div className="relative aspect-square w-full">
@@ -138,7 +138,7 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
                     aria-label="削除"
                     disabled={isPending}
                     onClick={() => handleDelete(r.id)}
-                    className="absolute top-2 right-2 w-6 h-6 flex items-center justify-center rounded-full bg-white/90 text-red-500 hover:text-red-700 text-xs shadow disabled:opacity-50 cursor-pointer"
+                    className="absolute top-2 right-2 w-6 h-6 flex items-center justify-center rounded-full bg-white/90 text-red-500 hover:text-red-700 active:text-red-800 text-xs shadow disabled:opacity-50 cursor-pointer"
                   >
                     ✕
                   </button>
@@ -162,19 +162,19 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
         <div className="flex gap-2 mb-4">
           <Link
             href={`/recipes/new?from=/calendar/${date}`}
-            className="flex-1 text-center px-3 py-2 text-xs font-medium border border-zinc-300 rounded-lg text-zinc-700 hover:bg-zinc-50 transition-colors"
+            className="flex-1 text-center px-3 py-2 text-xs font-medium border border-zinc-300 rounded-lg text-zinc-700 hover:bg-zinc-50 active:bg-zinc-100 transition-colors"
           >
             手動で作成
           </Link>
           <Link
             href={`/recipes/new/from-url?from=/calendar/${date}`}
-            className="flex-1 text-center px-3 py-2 text-xs font-medium border border-zinc-300 rounded-lg text-zinc-700 hover:bg-zinc-50 transition-colors"
+            className="flex-1 text-center px-3 py-2 text-xs font-medium border border-zinc-300 rounded-lg text-zinc-700 hover:bg-zinc-50 active:bg-zinc-100 transition-colors"
           >
             URLから作成
           </Link>
           <Link
             href={`/recipes/new/from-photo?from=/calendar/${date}`}
-            className="flex-1 text-center px-3 py-2 text-xs font-medium border border-zinc-300 rounded-lg text-zinc-700 hover:bg-zinc-50 transition-colors"
+            className="flex-1 text-center px-3 py-2 text-xs font-medium border border-zinc-300 rounded-lg text-zinc-700 hover:bg-zinc-50 active:bg-zinc-100 transition-colors"
           >
             写真から作成
           </Link>
@@ -206,7 +206,7 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
                           aria-label="追加"
                           disabled={isPending}
                           onClick={() => handleAddClick(recipe.id)}
-                          className="w-full px-2 py-1 text-xs font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 disabled:opacity-50 cursor-pointer"
+                          className="w-full px-2 py-1 text-xs font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 active:bg-zinc-800 disabled:opacity-50 cursor-pointer"
                         >
                           追加
                         </button>
@@ -217,14 +217,14 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
                           <button
                             type="button"
                             onClick={() => handleSelectType('ate')}
-                            className="flex-1 px-2 py-1 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 cursor-pointer"
+                            className="flex-1 px-2 py-1 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 active:bg-blue-800 cursor-pointer"
                           >
                             食べた
                           </button>
                           <button
                             type="button"
                             onClick={() => handleSelectType('cooked')}
-                            className="flex-1 px-2 py-1 text-xs font-medium bg-green-600 text-white rounded-lg hover:bg-green-700 cursor-pointer"
+                            className="flex-1 px-2 py-1 text-xs font-medium bg-green-600 text-white rounded-lg hover:bg-green-700 active:bg-green-800 cursor-pointer"
                           >
                             作った
                           </button>
@@ -238,7 +238,7 @@ export default function MealDateClient({ date, recipes, mealRecords }: Props) {
                               key={key}
                               type="button"
                               onClick={() => handleSelectMealTime(key)}
-                              className="flex-1 px-2 py-1 text-xs font-medium bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 cursor-pointer"
+                              className="flex-1 px-2 py-1 text-xs font-medium bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 active:bg-blue-300 cursor-pointer"
                             >
                               {label}
                             </button>

--- a/app/calendar/[date]/page.tsx
+++ b/app/calendar/[date]/page.tsx
@@ -51,7 +51,7 @@ export default async function CalendarDatePage({ params }: Props) {
     <div className="min-h-screen bg-zinc-50">
       <header className="bg-white border-b border-zinc-200">
         <div className="max-w-7xl mx-auto px-4 py-4 flex items-center gap-4">
-          <Link href="/?tab=calendar" className="text-sm text-zinc-500 hover:text-zinc-900 active:text-zinc-700 transition-colors">
+          <Link href="/?tab=calendar" className="text-sm text-zinc-500 hover:text-zinc-900 px-2 py-1 rounded-lg hover:bg-zinc-100 active:bg-zinc-200 transition-colors">
             ← カレンダーへ
           </Link>
           <h1 className="text-lg font-semibold text-zinc-900">{formatDateLabel(date)}</h1>

--- a/app/calendar/[date]/page.tsx
+++ b/app/calendar/[date]/page.tsx
@@ -51,7 +51,7 @@ export default async function CalendarDatePage({ params }: Props) {
     <div className="min-h-screen bg-zinc-50">
       <header className="bg-white border-b border-zinc-200">
         <div className="max-w-7xl mx-auto px-4 py-4 flex items-center gap-4">
-          <Link href="/?tab=calendar" className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+          <Link href="/?tab=calendar" className="text-sm text-zinc-500 hover:text-zinc-900 active:text-zinc-700 transition-colors">
             ← カレンダーへ
           </Link>
           <h1 className="text-lg font-semibold text-zinc-900">{formatDateLabel(date)}</h1>

--- a/app/components/AddRecipeDropdown.tsx
+++ b/app/components/AddRecipeDropdown.tsx
@@ -22,7 +22,7 @@ export default function AddRecipeDropdown() {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="px-4 py-2 rounded-lg bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 transition-colors flex items-center gap-1"
+        className="px-4 py-2 rounded-lg bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 active:bg-zinc-800 transition-colors flex items-center gap-1"
       >
         + レシピを追加
         <span className="text-xs">▾</span>
@@ -32,7 +32,7 @@ export default function AddRecipeDropdown() {
           <Link
             href="/recipes/new"
             onClick={() => setOpen(false)}
-            className="block px-4 py-3 text-sm text-zinc-700 hover:bg-zinc-50 transition-colors"
+            className="block px-4 py-3 text-sm text-zinc-700 hover:bg-zinc-50 active:bg-zinc-100 transition-colors"
           >
             手動で作成
           </Link>

--- a/app/components/CalendarView.tsx
+++ b/app/components/CalendarView.tsx
@@ -136,7 +136,7 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
           type="button"
           aria-label="前月"
           onClick={goToPrevMonth}
-          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 transition-colors cursor-pointer"
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 active:bg-zinc-200 transition-colors cursor-pointer"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
           前月
@@ -148,7 +148,7 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
           type="button"
           aria-label="翌月"
           onClick={goToNextMonth}
-          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 transition-colors cursor-pointer"
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 active:bg-zinc-200 transition-colors cursor-pointer"
         >
           翌月
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
@@ -182,7 +182,7 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
               type="button"
               data-testid={`cell-${cell.dateKey}`}
               onClick={() => router.push(`/calendar/${cell.dateKey}`)}
-              className="bg-white p-1 flex flex-col items-center transition-colors hover:bg-zinc-50 cursor-pointer"
+              className="bg-white p-1 flex flex-col items-center transition-colors hover:bg-zinc-50 active:bg-zinc-100 cursor-pointer"
             >
               <span className={`text-xs mb-0.5 ${dayColor}`}>{cell.day}</span>
               {cell.holidayName && (

--- a/app/components/CalendarView.tsx
+++ b/app/components/CalendarView.tsx
@@ -109,6 +109,7 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
     const base = initialMonth ?? new Date()
     return new Date(base.getFullYear(), base.getMonth(), 1)
   })
+  const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null)
 
   const year = currentMonth.getFullYear()
   const month = currentMonth.getMonth()
@@ -127,6 +128,14 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
 
   const goToPrevMonth = () => setCurrentMonth(new Date(year, month - 1, 1))
   const goToNextMonth = () => setCurrentMonth(new Date(year, month + 1, 1))
+
+  const handleCellClick = (dateKey: string) => {
+    if (selectedDateKey === dateKey) {
+      router.push(`/calendar/${dateKey}`)
+    } else {
+      setSelectedDateKey(dateKey)
+    }
+  }
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -176,13 +185,15 @@ export default function CalendarView({ mealRecords, recipes: _recipes, initialMo
           const dayRecords = cell.isCurrentMonth ? (recordsByDate[cell.dateKey] ?? []) : []
           const dayColor = getDayColor(cell.dayOfWeek, cell.holidayName, cell.isCurrentMonth)
 
+          const isSelected = selectedDateKey === cell.dateKey
+
           return (
             <button
               key={cell.dateKey}
               type="button"
               data-testid={`cell-${cell.dateKey}`}
-              onClick={() => router.push(`/calendar/${cell.dateKey}`)}
-              className="bg-white p-1 flex flex-col items-center transition-colors hover:bg-zinc-50 active:bg-zinc-100 cursor-pointer"
+              onClick={() => handleCellClick(cell.dateKey)}
+              className={`p-1 flex flex-col items-center transition-colors cursor-pointer ${isSelected ? 'bg-zinc-100' : 'bg-white hover:bg-zinc-50 active:bg-zinc-100'}`}
             >
               <span className={`text-xs mb-0.5 ${dayColor}`}>{cell.day}</span>
               {cell.holidayName && (

--- a/app/components/HomeTabs.tsx
+++ b/app/components/HomeTabs.tsx
@@ -75,7 +75,7 @@ export default function HomeTabs({ recipes, mealRecords, user, recipeCount }: Ho
                 <form action={signOut}>
                   <button
                     type="submit"
-                    className="text-sm font-medium text-red-600 hover:text-red-800 transition-colors cursor-pointer"
+                    className="text-sm font-medium text-red-600 hover:text-red-800 active:text-red-900 transition-colors cursor-pointer"
                   >
                     ログアウト
                   </button>
@@ -97,7 +97,7 @@ export default function HomeTabs({ recipes, mealRecords, user, recipeCount }: Ho
               key={key}
               type="button"
               onClick={() => setActiveTab(key)}
-              className={`px-5 py-2 rounded-full text-sm font-medium transition-colors cursor-pointer ${activeTab === key ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'}`}
+              className={`px-5 py-2 rounded-full text-sm font-medium transition-colors cursor-pointer ${activeTab === key ? 'bg-zinc-900 text-white active:bg-zinc-700' : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200 active:bg-zinc-300'}`}
             >
               {label}
             </button>

--- a/app/components/RecipeList.tsx
+++ b/app/components/RecipeList.tsx
@@ -31,7 +31,7 @@ export default function RecipeList({ recipes }: RecipeListProps) {
         <li key={recipe.id}>
           <Link
             href={`/recipes/${recipe.id}`}
-            className="flex flex-col bg-white rounded-xl border border-zinc-200 hover:border-zinc-400 transition-colors overflow-hidden h-full"
+            className="flex flex-col bg-white rounded-xl border border-zinc-200 hover:border-zinc-400 active:bg-zinc-50 transition-colors overflow-hidden h-full"
           >
             {recipe.images[0]?.url ? (
               <div className="relative aspect-square w-full">

--- a/app/components/WeekView.tsx
+++ b/app/components/WeekView.tsx
@@ -100,7 +100,7 @@ export default function WeekView({ mealRecords, initialDate }: WeekViewProps) {
           type="button"
           aria-label="前週"
           onClick={goToPrevWeek}
-          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 transition-colors cursor-pointer"
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 active:bg-zinc-200 transition-colors cursor-pointer"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
           前週
@@ -110,7 +110,7 @@ export default function WeekView({ mealRecords, initialDate }: WeekViewProps) {
           type="button"
           aria-label="翌週"
           onClick={goToNextWeek}
-          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 transition-colors cursor-pointer"
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 active:bg-zinc-200 transition-colors cursor-pointer"
         >
           翌週
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
@@ -125,7 +125,7 @@ export default function WeekView({ mealRecords, initialDate }: WeekViewProps) {
             type="button"
             onClick={() => setFilter(f)}
             className={`px-3 py-1 rounded-full text-xs font-medium transition-colors cursor-pointer ${
-              filter === f ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'
+              filter === f ? 'bg-zinc-900 text-white active:bg-zinc-700' : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200 active:bg-zinc-300'
             }`}
           >
             {f === 'all' ? 'すべて' : f === 'ate' ? '食べた' : '作った'}
@@ -154,7 +154,7 @@ export default function WeekView({ mealRecords, initialDate }: WeekViewProps) {
               type="button"
               data-testid={`day-row-${dateKey}`}
               onClick={() => router.push(`/calendar/${dateKey}`)}
-              className={`w-full text-left rounded-xl border px-3 py-2 transition-colors cursor-pointer hover:bg-zinc-50 ${
+              className={`w-full text-left rounded-xl border px-3 py-2 transition-colors cursor-pointer hover:bg-zinc-50 active:bg-zinc-100 ${
                 isToday ? 'border-zinc-400 bg-zinc-50' : 'border-zinc-200 bg-white'
               }`}
             >

--- a/app/components/WeekView.tsx
+++ b/app/components/WeekView.tsx
@@ -105,7 +105,14 @@ export default function WeekView({ mealRecords, initialDate }: WeekViewProps) {
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
           前週
         </button>
-        <span className="text-sm font-semibold text-zinc-900">{rangeLabel}</span>
+        <button
+          type="button"
+          aria-label="今週"
+          onClick={() => setWeekMonday(getWeekMonday(new Date()))}
+          className="text-sm font-semibold text-zinc-900 hover:text-zinc-600 active:text-zinc-400 transition-colors cursor-pointer"
+        >
+          {rangeLabel}
+        </button>
         <button
           type="button"
           aria-label="翌週"

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/app/recipes/[id]/BackButton.tsx
+++ b/app/recipes/[id]/BackButton.tsx
@@ -8,7 +8,7 @@ export default function BackButton() {
     <button
       type="button"
       onClick={() => router.back()}
-      className="text-sm text-zinc-500 hover:text-zinc-900 active:text-zinc-700 transition-colors cursor-pointer"
+      className="text-sm text-zinc-500 hover:text-zinc-900 px-2 py-1 rounded-lg hover:bg-zinc-100 active:bg-zinc-200 transition-colors cursor-pointer"
     >
       ← 戻る
     </button>

--- a/app/recipes/[id]/BackButton.tsx
+++ b/app/recipes/[id]/BackButton.tsx
@@ -8,7 +8,7 @@ export default function BackButton() {
     <button
       type="button"
       onClick={() => router.back()}
-      className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors cursor-pointer"
+      className="text-sm text-zinc-500 hover:text-zinc-900 active:text-zinc-700 transition-colors cursor-pointer"
     >
       ← 戻る
     </button>

--- a/app/recipes/[id]/DeleteButton.tsx
+++ b/app/recipes/[id]/DeleteButton.tsx
@@ -17,7 +17,7 @@ export default function DeleteButton({ recipeId }: { recipeId: string }) {
       type="button"
       onClick={handleDelete}
       disabled={isPending}
-      className="px-4 py-2 rounded-lg text-sm font-medium text-red-600 border border-red-200 hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      className="px-4 py-2 rounded-lg text-sm font-medium text-red-600 border border-red-200 hover:bg-red-50 active:bg-red-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {isPending ? '削除中...' : 'レシピを削除'}
     </button>

--- a/app/recipes/[id]/ImageGallery.tsx
+++ b/app/recipes/[id]/ImageGallery.tsx
@@ -30,7 +30,7 @@ export default function ImageGallery({ images, alt }: Props) {
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="relative w-full aspect-[4/3] rounded-xl overflow-hidden cursor-zoom-in block"
+          className="relative w-full aspect-[4/3] rounded-xl overflow-hidden cursor-zoom-in block active:opacity-90 transition-opacity"
         >
           <Image
             src={activeImage.url}
@@ -50,7 +50,7 @@ export default function ImageGallery({ images, alt }: Props) {
                 key={img.url}
                 type="button"
                 onClick={() => setActiveIndex(index)}
-                className={`relative flex-shrink-0 w-14 h-14 rounded-lg overflow-hidden border-2 transition-colors ${index === activeIndex ? 'border-zinc-900' : 'border-transparent'}`}
+                className={`relative flex-shrink-0 w-14 h-14 rounded-lg overflow-hidden border-2 transition-colors active:opacity-80 ${index === activeIndex ? 'border-zinc-900' : 'border-transparent'}`}
               >
                 <Image
                   src={img.url}
@@ -73,7 +73,7 @@ export default function ImageGallery({ images, alt }: Props) {
           <button
             type="button"
             onClick={() => setOpen(false)}
-            className="self-end text-white text-sm hover:text-zinc-300 transition-colors cursor-pointer"
+            className="self-end text-white text-sm hover:text-zinc-300 active:text-zinc-400 transition-colors cursor-pointer"
           >
             閉じる ✕
           </button>
@@ -93,7 +93,7 @@ export default function ImageGallery({ images, alt }: Props) {
                   key={img.url}
                   type="button"
                   onClick={() => setActiveIndex(index)}
-                  className={`relative flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden border-2 transition-colors ${index === activeIndex ? 'border-white' : 'border-white/30'}`}
+                  className={`relative flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden border-2 transition-colors active:opacity-80 ${index === activeIndex ? 'border-white' : 'border-white/30'}`}
                 >
                   <Image
                     src={img.url}

--- a/app/recipes/[id]/edit/EditRecipeForm.tsx
+++ b/app/recipes/[id]/edit/EditRecipeForm.tsx
@@ -179,7 +179,7 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
           <button
             type="button"
             onClick={() => router.back()}
-            className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors"
+            className="text-sm text-zinc-500 hover:text-zinc-900 active:text-zinc-700 transition-colors"
           >
             ← 戻る
           </button>
@@ -239,7 +239,7 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
             )}
 
             {!imagePreviewUrl && (
-              <label className="flex flex-col items-center justify-center w-full h-32 rounded-lg border-2 border-dashed border-zinc-300 cursor-pointer hover:border-zinc-400 transition-colors">
+              <label className="flex flex-col items-center justify-center w-full h-32 rounded-lg border-2 border-dashed border-zinc-300 cursor-pointer hover:border-zinc-400 active:bg-zinc-50 transition-colors">
                 <span className="text-sm text-zinc-500">タップして写真を追加</span>
                 <input
                   type="file"
@@ -324,7 +324,7 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
               <button
                 type="button"
                 onClick={addCategory}
-                className="px-4 py-2 text-sm font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 transition-colors"
+                className="px-4 py-2 text-sm font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 active:bg-zinc-800 transition-colors"
               >
                 追加
               </button>
@@ -334,7 +334,7 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
                 {categories.map((cat) => (
                   <span key={cat} className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm bg-zinc-100 text-zinc-700">
                     {cat}
-                    <button type="button" onClick={() => removeCategory(cat)} className="text-zinc-400 hover:text-zinc-700 transition-colors leading-none">×</button>
+                    <button type="button" onClick={() => removeCategory(cat)} className="text-zinc-400 hover:text-zinc-700 active:text-zinc-900 transition-colors leading-none">×</button>
                   </span>
                 ))}
               </div>
@@ -369,12 +369,12 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
                     className="w-20 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
                   />
                   {ingredients.length > 1 && (
-                    <button type="button" onClick={() => removeIngredient(index)} className="text-zinc-400 hover:text-red-500 transition-colors text-lg leading-none">×</button>
+                    <button type="button" onClick={() => removeIngredient(index)} className="text-zinc-400 hover:text-red-500 active:text-red-600 transition-colors text-lg leading-none">×</button>
                   )}
                 </div>
               ))}
             </div>
-            <button type="button" onClick={addIngredient} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+            <button type="button" onClick={addIngredient} className="text-sm text-zinc-500 hover:text-zinc-900 active:text-zinc-700 transition-colors">
               + 材料を追加
             </button>
           </section>
@@ -396,12 +396,12 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
                     className="flex-1 rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 resize-none"
                   />
                   {steps.length > 1 && (
-                    <button type="button" onClick={() => removeStep(index)} className="mt-2.5 text-zinc-400 hover:text-red-500 transition-colors text-lg leading-none">×</button>
+                    <button type="button" onClick={() => removeStep(index)} className="mt-2.5 text-zinc-400 hover:text-red-500 active:text-red-600 transition-colors text-lg leading-none">×</button>
                   )}
                 </div>
               ))}
             </div>
-            <button type="button" onClick={addStep} className="text-sm text-zinc-500 hover:text-zinc-900 transition-colors">
+            <button type="button" onClick={addStep} className="text-sm text-zinc-500 hover:text-zinc-900 active:text-zinc-700 transition-colors">
               + 手順を追加
             </button>
           </section>
@@ -411,14 +411,14 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
             <button
               type="button"
               onClick={() => router.back()}
-              className="flex-1 py-3 rounded-xl border border-zinc-300 text-sm font-medium text-zinc-700 hover:bg-zinc-50 transition-colors"
+              className="flex-1 py-3 rounded-xl border border-zinc-300 text-sm font-medium text-zinc-700 hover:bg-zinc-50 active:bg-zinc-100 transition-colors"
             >
               キャンセル
             </button>
             <button
               type="submit"
               disabled={isPending}
-              className="flex-1 py-3 rounded-xl bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 py-3 rounded-xl bg-zinc-900 text-white text-sm font-medium hover:bg-zinc-700 active:bg-zinc-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isPending ? '保存中...' : '変更を保存'}
             </button>

--- a/app/recipes/[id]/edit/EditRecipeForm.tsx
+++ b/app/recipes/[id]/edit/EditRecipeForm.tsx
@@ -179,7 +179,7 @@ export default function EditRecipeForm({ recipeId, initialValues }: Props) {
           <button
             type="button"
             onClick={() => router.back()}
-            className="text-sm text-zinc-500 hover:text-zinc-900 active:text-zinc-700 transition-colors"
+            className="text-sm text-zinc-500 hover:text-zinc-900 px-2 py-1 rounded-lg hover:bg-zinc-100 active:bg-zinc-200 transition-colors"
           >
             ← 戻る
           </button>

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -36,7 +36,7 @@ export default async function RecipeDetailPage({ params }: Props) {
           <div className="flex-1" />
           <Link
             href={`/recipes/${recipe.id}/edit`}
-            className="px-4 py-2 rounded-lg text-sm font-medium text-zinc-700 border border-zinc-200 hover:bg-zinc-50 transition-colors"
+            className="px-4 py-2 rounded-lg text-sm font-medium text-zinc-700 border border-zinc-200 hover:bg-zinc-50 active:bg-zinc-100 transition-colors"
           >
             編集
           </Link>


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
スマホで操作する時の使いにくさ（タップしたかどうかが分かりにくい）ことの改善

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #66 

## やったこと
<!-- このPRで何をしたのか -->
- app/globals.css — * { -webkit-tap-highlight-color: transparent; } を追加。OSデフォルトの青/グレーのタップハイライトを無効化
- app/components/AddRecipeDropdown.tsx — プライマリボタンに active:bg-zinc-800、ドロップダウン各リンクに active:bg-zinc-100 を追加
- app/components/HomeTabs.tsx — ボトムナビのアクティブタブに active:bg-zinc-700、非アクティブタブに active:bg-zinc-300、ログアウトボタンに active:text-red-900 を追加
- app/components/RecipeList.tsx — レシピカードに active:bg-zinc-50 を追加
- app/components/CalendarView.tsx — カレンダーセルに active:bg-zinc-100、前月/翌月ボタンに active:bg-zinc-200 を追加
- app/components/WeekView.tsx — 週の各日行に active:bg-zinc-100、前週/翌週ボタンに active:bg-zinc-200、フィルターボタン（非アクティブ）に
active:bg-zinc-300、フィルターボタン（アクティブ）に active:bg-zinc-700 を追加
- app/recipes/[id]/DeleteButton.tsx — 削除ボタンに active:bg-red-100 を追加
- app/recipes/[id]/BackButton.tsx — 戻るボタンに active:text-zinc-700 を追加
- app/recipes/[id]/ImageGallery.tsx — メイン画像ボタンに active:opacity-90、サムネイルに active:opacity-80、閉じるボタンに active:text-zinc-400 を追加
- app/recipes/[id]/edit/EditRecipeForm.tsx — 戻るボタン、材料/手順追加ボタンに active:text-zinc-700、カテゴリ追加・保存ボタンに active:bg-zinc-800、削除ボタン（×）に
active:text-red-600、キャンセルボタンに active:bg-zinc-100、写真追加ラベルに active:bg-zinc-50 を追加
- app/calendar/[date]/MealDateClient.tsx — レシピカードに active:bg-zinc-50、カード内削除ボタンに active:text-red-800、作成リンク3種に active:bg-zinc-100、追加ボタン（黒）に
active:bg-zinc-800、食べた（青）に active:bg-blue-800、作った（緑）に active:bg-green-800、時間帯ボタンに active:bg-blue-300 を追加


## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
