### PR TITLE
【feature/71】レシピアプリから正確なURLを抽出できるよう修正

### DIFF
--- a/app/recipes/new/from-url/page.test.tsx
+++ b/app/recipes/new/from-url/page.test.tsx
@@ -32,6 +32,7 @@ const validRecipe: ParsedRecipe = {
   cookTime: 30,
   ingredients: [{ name: '玉ねぎ', amount: '1', unit: '個' }],
   steps: ['玉ねぎを炒める', 'カレールーを加える'],
+  imageUrl: null,
 }
 
 describe('FromUrlPage', () => {
@@ -223,6 +224,84 @@ describe('FromUrlPage', () => {
         expect.objectContaining({ title: 'カレーライス' }),
         undefined
       )
+    })
+  })
+
+  describe('URL正規化', () => {
+    it('#share_ios 付きURL → フラグメントを除去して parseRecipeFromUrl が呼ばれる', async () => {
+      const user = userEvent.setup()
+      render(<FromUrlPage />)
+
+      await user.type(
+        screen.getByPlaceholderText('https://example.com/recipe'),
+        'https://delishkitchen.tv/recipes/147726740259602726#share_ios'
+      )
+      await user.click(screen.getByText('URLから読み込む'))
+
+      await waitFor(() => {
+        expect(mockParseRecipeFromUrl).toHaveBeenCalledWith(
+          'https://delishkitchen.tv/recipes/147726740259602726'
+        )
+      })
+    })
+
+    it('#share_ios 付きURL → 入力フィールドが正規化URLに更新される', async () => {
+      const user = userEvent.setup()
+      render(<FromUrlPage />)
+
+      await user.type(
+        screen.getByPlaceholderText('https://example.com/recipe'),
+        'https://delishkitchen.tv/recipes/147726740259602726#share_ios'
+      )
+      await user.click(screen.getByText('URLから読み込む'))
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('https://delishkitchen.tv/recipes/147726740259602726')).toBeInTheDocument()
+      })
+    })
+
+    it('テキスト埋め込みURL → URLを抽出して parseRecipeFromUrl が呼ばれる', async () => {
+      const user = userEvent.setup()
+      render(<FromUrlPage />)
+
+      await user.type(
+        screen.getByPlaceholderText('https://example.com/recipe'),
+        'パクパク食べれる！基本のホイコーロー https://example.com/recipe/123'
+      )
+      await user.click(screen.getByText('URLから読み込む'))
+
+      await waitFor(() => {
+        expect(mockParseRecipeFromUrl).toHaveBeenCalledWith('https://example.com/recipe/123')
+      })
+    })
+
+    it('UTMパラメータ付きURL → UTMを除去して parseRecipeFromUrl が呼ばれる', async () => {
+      const user = userEvent.setup()
+      render(<FromUrlPage />)
+
+      await user.type(
+        screen.getByPlaceholderText('https://example.com/recipe'),
+        'https://example.com/recipe?utm_source=twitter'
+      )
+      await user.click(screen.getByText('URLから読み込む'))
+
+      await waitFor(() => {
+        expect(mockParseRecipeFromUrl).toHaveBeenCalledWith('https://example.com/recipe')
+      })
+    })
+
+    it('URLを含まないテキスト → バリデーションエラーが表示される', async () => {
+      const user = userEvent.setup()
+      render(<FromUrlPage />)
+
+      await user.type(
+        screen.getByPlaceholderText('https://example.com/recipe'),
+        'これはURLではありません'
+      )
+      await user.click(screen.getByText('URLから読み込む'))
+
+      expect(screen.getByText('有効なURLを入力してください。')).toBeInTheDocument()
+      expect(mockParseRecipeFromUrl).not.toHaveBeenCalled()
     })
   })
 })

--- a/app/recipes/new/from-url/page.tsx
+++ b/app/recipes/new/from-url/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 import { createRecipe, type IngredientInput, type StepInput } from '../../actions'
 import { parseRecipeFromUrl } from '../../../utils/recipeUrlParser'
+import { normalizeUrl } from '../../../utils/urlNormalizer'
 
 function FromUrlPageInner() {
   const router = useRouter()
@@ -35,17 +36,17 @@ function FromUrlPageInner() {
       setUrlError('URLを入力してください。')
       return
     }
-    try {
-      new URL(url)
-    } catch {
+    const normalized = normalizeUrl(url)
+    if (!normalized) {
       setUrlError('有効なURLを入力してください。')
       return
     }
+    setUrl(normalized)
     setUrlError(null)
     setParseError(null)
     setIsParsing(true)
     try {
-      const parsed = await parseRecipeFromUrl(url)
+      const parsed = await parseRecipeFromUrl(normalized)
       if (parsed.title !== null) setTitle(parsed.title)
       if (parsed.description !== null) setDescription(parsed.description)
       if (parsed.servings !== null) setServings(String(parsed.servings))
@@ -162,7 +163,7 @@ function FromUrlPageInner() {
             )}
             <div className="flex gap-2">
               <input
-                type="url"
+                type="text"
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
                 placeholder="https://example.com/recipe"

--- a/app/utils/urlNormalizer.test.ts
+++ b/app/utils/urlNormalizer.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeUrl } from './urlNormalizer'
+
+describe('normalizeUrl', () => {
+  it('フラグメントなし正常URL → そのまま返す', () => {
+    expect(normalizeUrl('https://example.com/recipe/123')).toBe('https://example.com/recipe/123')
+  })
+
+  it('#share_ios フラグメント → 除去する', () => {
+    expect(normalizeUrl('https://delishkitchen.tv/recipes/147726740259602726#share_ios')).toBe(
+      'https://delishkitchen.tv/recipes/147726740259602726'
+    )
+  })
+
+  it('#share_android フラグメント → 除去する', () => {
+    expect(normalizeUrl('https://example.com/recipe#share_android')).toBe(
+      'https://example.com/recipe'
+    )
+  })
+
+  it('utm_source パラメータ → 除去する', () => {
+    expect(normalizeUrl('https://example.com/recipe?utm_source=twitter')).toBe(
+      'https://example.com/recipe'
+    )
+  })
+
+  it('utm_medium + utm_campaign → 両方除去する', () => {
+    expect(normalizeUrl('https://example.com/recipe?utm_medium=social&utm_campaign=summer')).toBe(
+      'https://example.com/recipe'
+    )
+  })
+
+  it('UTMと非UTMが混在 → UTMのみ除去、他は保持する', () => {
+    expect(normalizeUrl('https://example.com/recipe?id=123&utm_source=twitter&page=1')).toBe(
+      'https://example.com/recipe?id=123&page=1'
+    )
+  })
+
+  it('日本語テキスト + スペース + URL → URLを抽出する', () => {
+    expect(
+      normalizeUrl('パクパク食べれる！基本のホイコーロー https://delishkitchen.tv/recipes/147726740259602726')
+    ).toBe('https://delishkitchen.tv/recipes/147726740259602726')
+  })
+
+  it('テキスト埋め込みURL + フラグメント → 抽出してフラグメント除去する', () => {
+    expect(
+      normalizeUrl('台湾まぜうどん https://example.com/recipe/456#share_ios')
+    ).toBe('https://example.com/recipe/456')
+  })
+
+  it('テキスト埋め込みURL + UTM → 抽出してUTM除去する', () => {
+    expect(
+      normalizeUrl('レシピ https://example.com/recipe?utm_source=app')
+    ).toBe('https://example.com/recipe')
+  })
+
+  it('全角スペース区切り → URLを抽出する', () => {
+    expect(
+      normalizeUrl('パクパク食べれる！　https://example.com/recipe/789')
+    ).toBe('https://example.com/recipe/789')
+  })
+
+  it('URLを含まない文字列 → null を返す', () => {
+    expect(normalizeUrl('これはURLではありません')).toBeNull()
+  })
+
+  it('空文字列 → null を返す', () => {
+    expect(normalizeUrl('')).toBeNull()
+  })
+
+  it('ftp:// URL → null を返す', () => {
+    expect(normalizeUrl('ftp://example.com/file')).toBeNull()
+  })
+
+  it('テキストに ftp:// と https:// が両方ある → https:// のURLを返す', () => {
+    expect(normalizeUrl('ftp://old.com https://example.com/recipe')).toBe('https://example.com/recipe')
+  })
+})

--- a/app/utils/urlNormalizer.ts
+++ b/app/utils/urlNormalizer.ts
@@ -1,0 +1,38 @@
+export function normalizeUrl(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  // 直接URLとして解析を試みる
+  let rawUrl = trimmed
+  try {
+    const parsed = new URL(rawUrl)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return cleanUrl(parsed)
+    }
+    // http/https以外（ftp:// など）は次のステップへ
+  } catch {
+    // URLとして解析失敗 → テキスト内からURLを探す
+  }
+
+  // テキスト内の最初の http:// または https:// のURLを抽出（全角スペース対応）
+  const match = trimmed.match(/(https?:\/\/[^\s　]+)/)
+  if (!match) return null
+
+  try {
+    const parsed = new URL(match[1])
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    return cleanUrl(parsed)
+  } catch {
+    return null
+  }
+}
+
+function cleanUrl(url: URL): string {
+  url.hash = ''
+  for (const key of [...url.searchParams.keys()]) {
+    if (key.startsWith('utm_')) {
+      url.searchParams.delete(key)
+    }
+  }
+  return url.toString()
+}


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
レシピアプリからURLをコピーすると、解析できない形式になっていることがあるので、正確な形式で抽出するように修正。

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #71 

## やったこと
<!-- このPRで何をしたのか -->
- app/utils/urlNormalizer.ts を新規作成 — normalizeUrl(input: string): string | null 関数を実装
  - テキスト内からhttp/https URLを抽出（全角スペース対応）
  - フラグメント（#share_ios, #share_android など）を除去
  - UTMパラメータ（utm_*）を除去
  - 有効なURLが見つからなければ null を返す
- app/utils/urlNormalizer.test.ts を新規作成 — 14ケースのユニットテスト（TDD: 実装前に作成）
- app/recipes/new/from-url/page.tsx を修正
  - handleLoadUrl のURL検証を normalizeUrl に置き換え
  - 正規化したURLを setUrl() で入力フィールドに反映（ユーザーへの視覚フィードバック）
  - parseRecipeFromUrl に正規化済みURLを渡すよう変更
  - <input type="url"> → <input type="text"> に変更（ブラウザのネイティブURL制限を回避）
- app/recipes/new/from-url/page.test.tsx を修正
  - validRecipe に imageUrl: null を追加（型修正）
  - URL正規化の統合テストを5ケース追加
 
## やらないこと
<!-- このPRでやらないことは何か -->
-

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
