### PR TITLE
【feature/70】タブを切り替える時にURLを都度更新するように修正

### DIFF
--- a/app/components/HomeTabs.tsx
+++ b/app/components/HomeTabs.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import RecipeList from './RecipeList'
 import WeekView from './WeekView'
 import AccountTab from './AccountTab'
@@ -36,10 +36,13 @@ type HomeTabsProps = {
 type Tab = 'list' | 'calendar' | 'account'
 
 export default function HomeTabs({ recipes, mealRecords, user, recipeCount }: HomeTabsProps) {
+  const router = useRouter()
   const searchParams = useSearchParams()
-  const [activeTab, setActiveTab] = useState<Tab>(
-    searchParams.get('tab') === 'calendar' ? 'calendar' : 'list'
-  )
+  const [activeTab, setActiveTab] = useState<Tab>(() => {
+    const tab = searchParams.get('tab')
+    if (tab === 'calendar' || tab === 'account') return tab
+    return 'list'
+  })
 
   return (
     <div className="min-h-screen flex flex-col bg-zinc-50">
@@ -78,7 +81,10 @@ export default function HomeTabs({ recipes, mealRecords, user, recipeCount }: Ho
             <button
               key={key}
               type="button"
-              onClick={() => setActiveTab(key)}
+              onClick={() => {
+                setActiveTab(key)
+                router.replace(key === 'list' ? '/' : `/?tab=${key}`)
+              }}
               className={`px-5 py-2 rounded-full text-sm font-medium transition-colors cursor-pointer ${activeTab === key ? 'bg-zinc-900 text-white active:bg-zinc-700' : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200 active:bg-zinc-300'}`}
             >
               {label}


### PR DESCRIPTION
<!-- ↓ この形式でタイトルを付けてください -->
<!-- 【feature/XXX】タイトルタイトル -->

## 概要
<!-- PRの背景・目的・概要 -->
戻るボタンを押した時にリストからアクセスしているのにカレンダーに遷移してしまう問題があったため、修正を行なった

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #70 

## やったこと
<!-- このPRで何をしたのか -->
- HomeTabs.tsx のタブボタンクリック時に router.replace() でURLを更新するよう変更
    - リスト → /、カレンダー → /?tab=calendar、アカウント → /?tab=account
- useRouter をインポートに追加
- タブ初期値の判定を calendar/account を正式に認識する形に改善（list がデフォルト）

## やらないこと
<!-- このPRでやらないことは何か -->
- なし

## 動作確認
<!-- どのように動作確認を行なったか -->
- [ ] ビルドが成功することを確認
- [ ] Lintエラーがないことを確認
- [ ] 主要機能の動作確認

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
-
